### PR TITLE
Fix typo in Form page

### DIFF
--- a/modules/docs/content/remote-functions/form.md
+++ b/modules/docs/content/remote-functions/form.md
@@ -41,7 +41,7 @@ makes it easy to write data to the server. It takes a callback that receives
 
 ```ts [src/routes/blog/data.remote.ts]
 import { Effect, Schema } from "effect";
-import { Query } from "svelte-effect-runtime";
+import { Form } from "svelte-effect-runtime";
 import { Database } from "$lib/server/database";
 import { User } from "$lib/server/hooks/user";
 import { NotSignedInError } from "$lib/common/errors";


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Corrects the Form docs code sample by importing `Form` from `svelte-effect-runtime` instead of `Query` to match the example usage.

<sup>Written for commit 45d0024503d63ebaccd1236c4db69c37bac18429. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

