### PR TITLE
Convert VSIX packaging to ESM

### DIFF
--- a/build/assets.ts
+++ b/build/assets.ts
@@ -27,14 +27,17 @@ try {
 }
 
 await Deno.mkdir(target_dist_dir, { recursive: true });
-await Deno.remove(package_runtime_dir, { recursive: true }).catch(() => undefined);
-await Deno.symlink(runtime_dir, package_runtime_dir, { type: "dir" });
+await Deno.remove(package_runtime_dir, { recursive: true }).catch(() =>
+  undefined
+);
 
 await Deno.remove(runtime_dir, { recursive: true }).catch(() => undefined);
 await Deno.mkdir(join(runtime_dir, "internal"), { recursive: true });
 await Deno.mkdir(join(runtime_dir, "chunks"), { recursive: true });
 
-const runtime_manifest = JSON.parse(await Deno.readTextFile(runtime_manifest_path));
+const runtime_manifest = JSON.parse(
+  await Deno.readTextFile(runtime_manifest_path),
+);
 const runtime_package_json = {
   type: "module",
   dependencies: {
@@ -48,7 +51,10 @@ await Deno.writeTextFile(
   `${JSON.stringify(runtime_package_json, null, 2)}\n`,
 );
 
-await Deno.copyFile(join(runtime_dist, "preprocess.js"), join(runtime_dir, "preprocess.js"));
+await Deno.copyFile(
+  join(runtime_dist, "preprocess.js"),
+  join(runtime_dir, "preprocess.js"),
+);
 await copy(join(runtime_dist, "internal"), join(runtime_dir, "internal"), {
   overwrite: true,
 });
@@ -62,3 +68,5 @@ try {
     throw error;
   }
 }
+
+await copy(runtime_dir, package_runtime_dir, { overwrite: true });

--- a/build/ext.ts
+++ b/build/ext.ts
@@ -1,28 +1,37 @@
+import { copy } from "@std/fs/copy";
 import { build } from "rolldown";
 import { dirname, fromFileUrl, join, resolve } from "@std/path";
 
-const package_dir = new URL(
-  "../modules/svelte-effect-runtime-vscode-extension/",
-  import.meta.url,
+const package_dir = fromFileUrl(
+  new URL(
+    "../modules/svelte-effect-runtime-vscode-extension/",
+    import.meta.url,
+  ),
 );
 const repo_root = resolve(dirname(fromFileUrl(import.meta.url)), "..");
-const output_dir = join(repo_root, "dist", "svelte-effect-runtime-vscode-extension");
-const package_dist = new URL("./dist", package_dir).pathname;
+const output_dir = join(
+  repo_root,
+  "dist",
+  "svelte-effect-runtime-vscode-extension",
+);
+const package_dist = join(package_dir, "dist");
+const package_runtime_dir = join(package_dir, "runtime");
+const output_runtime_dir = join(output_dir, "runtime");
 
+await Deno.remove(output_dir, { recursive: true }).catch(() => undefined);
 await Deno.mkdir(output_dir, { recursive: true });
 await Deno.remove(package_dist, { recursive: true }).catch(() => undefined);
-await Deno.symlink(output_dir, package_dist, { type: "dir" });
 
 await build({
   input: {
-    extension: new URL("./extension.ts", package_dir).pathname,
-    server: new URL("./server.ts", package_dir).pathname,
+    extension: join(package_dir, "extension.ts"),
+    server: join(package_dir, "server.ts"),
   },
   output: {
     dir: output_dir,
-    format: "cjs",
-    entryFileNames: "[name].cjs",
-    chunkFileNames: "chunks/[name]-[hash].cjs",
+    format: "esm",
+    entryFileNames: "[name].js",
+    chunkFileNames: "chunks/[name]-[hash].js",
     sourcemap: true,
   },
   external: [
@@ -33,3 +42,6 @@ await build({
     /^svelte-language-server$/,
   ],
 });
+
+await copy(package_runtime_dir, output_runtime_dir, { overwrite: true });
+await copy(output_dir, package_dist, { overwrite: true });

--- a/build/lsp.ts
+++ b/build/lsp.ts
@@ -1,20 +1,27 @@
+import { copy } from "@std/fs/copy";
 import { build } from "rolldown";
 import { dirname, fromFileUrl, join, resolve } from "@std/path";
 
-const package_dir = new URL(
-  "../modules/svelte-effect-runtime-language-server/",
-  import.meta.url,
+const package_dir = fromFileUrl(
+  new URL(
+    "../modules/svelte-effect-runtime-language-server/",
+    import.meta.url,
+  ),
 );
 const repo_root = resolve(dirname(fromFileUrl(import.meta.url)), "..");
-const output_dir = join(repo_root, "dist", "svelte-effect-runtime-language-server");
-const package_dist = new URL("./dist", package_dir).pathname;
+const output_dir = join(
+  repo_root,
+  "dist",
+  "svelte-effect-runtime-language-server",
+);
+const package_dist = join(package_dir, "dist");
 
+await Deno.remove(output_dir, { recursive: true }).catch(() => undefined);
 await Deno.mkdir(output_dir, { recursive: true });
 await Deno.remove(package_dist, { recursive: true }).catch(() => undefined);
-await Deno.symlink(output_dir, package_dist, { type: "dir" });
 
 await build({
-  input: new URL("./server.ts", package_dir).pathname,
+  input: join(package_dir, "server.ts"),
   output: {
     file: join(output_dir, "server.cjs"),
     format: "cjs",
@@ -28,3 +35,5 @@ await build({
     /^svelte-language-server$/,
   ],
 });
+
+await copy(output_dir, package_dist, { overwrite: true });

--- a/build/runtime.ts
+++ b/build/runtime.ts
@@ -2,10 +2,12 @@ import { copy } from "@std/fs/copy";
 import { build } from "rolldown";
 import { dirname, fromFileUrl, join, resolve } from "@std/path";
 
-const package_dir = new URL("../modules/svelte-effect-runtime/", import.meta.url);
+const package_dir = fromFileUrl(
+  new URL("../modules/svelte-effect-runtime/", import.meta.url),
+);
 const repo_root = resolve(dirname(fromFileUrl(import.meta.url)), "..");
 const output_dir = join(repo_root, "dist", "svelte-effect-runtime");
-const package_dist = new URL("./dist", package_dir).pathname;
+const package_dist = join(package_dir, "dist");
 
 await Deno.mkdir(output_dir, { recursive: true });
 await Deno.remove(package_dist, { recursive: true }).catch(() => undefined);
@@ -13,6 +15,7 @@ await Deno.remove(output_dir, { recursive: true }).catch(() => undefined);
 await Deno.mkdir(output_dir, { recursive: true });
 
 const external = [
+  /^node:/,
   /^\$app\/server$/,
   /^@sveltejs\/kit(?:\/.*)?$/,
   /^@sveltejs\/kit\/internal\/server$/,
@@ -25,18 +28,18 @@ const external = [
 
 await build({
   input: {
-    mod: new URL("./mod.ts", package_dir).pathname,
-    "root-node": new URL("./root-node.ts", package_dir).pathname,
-    effect: new URL("./effect.ts", package_dir).pathname,
-    client: new URL("./client.ts", package_dir).pathname,
-    server: new URL("./server.ts", package_dir).pathname,
-    preprocess: new URL("./preprocess.ts", package_dir).pathname,
-    vite: new URL("./vite.ts", package_dir).pathname,
-    "language-server": new URL("./language-server.ts", package_dir).pathname,
-    "internal/markup": new URL("./internal/markup.ts", package_dir).pathname,
-    "internal/remote-client": new URL("./internal/remote-client.ts", package_dir).pathname,
-    "internal/remote-shared": new URL("./internal/remote-shared.ts", package_dir).pathname,
-    "internal/transform": new URL("./internal/transform.ts", package_dir).pathname,
+    mod: join(package_dir, "mod.ts"),
+    "root-node": join(package_dir, "root-node.ts"),
+    effect: join(package_dir, "effect.ts"),
+    client: join(package_dir, "client.ts"),
+    server: join(package_dir, "server.ts"),
+    preprocess: join(package_dir, "preprocess.ts"),
+    vite: join(package_dir, "vite.ts"),
+    "language-server": join(package_dir, "language-server.ts"),
+    "internal/markup": join(package_dir, "internal", "markup.ts"),
+    "internal/remote-client": join(package_dir, "internal", "remote-client.ts"),
+    "internal/remote-shared": join(package_dir, "internal", "remote-shared.ts"),
+    "internal/transform": join(package_dir, "internal", "transform.ts"),
   },
   output: {
     dir: output_dir,

--- a/build/vsix.ts
+++ b/build/vsix.ts
@@ -2,31 +2,61 @@ import { copy } from "@std/fs/copy";
 import { dirname, fromFileUrl, join, resolve } from "@std/path";
 
 const repo_root = resolve(dirname(fromFileUrl(import.meta.url)), "..");
-const package_dir = join(repo_root, "modules", "svelte-effect-runtime-vscode-extension");
-const output_dir = join(repo_root, "dist", "svelte-effect-runtime-vscode-extension");
-const staging_dir = await Deno.makeTempDir({ prefix: "svelte-effect-runtime-vsix-" });
+const package_dir = join(
+  repo_root,
+  "modules",
+  "svelte-effect-runtime-vscode-extension",
+);
+const output_dir = join(
+  repo_root,
+  "dist",
+  "svelte-effect-runtime-vscode-extension",
+);
+const staging_dir = await Deno.makeTempDir({
+  prefix: "svelte-effect-runtime-vsix-",
+});
 const staging_dist_dir = join(staging_dir, "dist");
+const required_runtime_dependencies = [
+  "svelte-language-server",
+];
 
 await Deno.mkdir(staging_dist_dir, { recursive: true });
-await copy(join(output_dir, "chunks"), join(staging_dist_dir, "chunks"), { overwrite: true }).catch(
+await copy(join(output_dir, "chunks"), join(staging_dist_dir, "chunks"), {
+  overwrite: true,
+}).catch(
   (error) => {
     if (!(error instanceof Deno.errors.NotFound)) {
       throw error;
     }
   },
 );
-for (const filename of ["extension.cjs", "extension.cjs.map", "server.cjs", "server.cjs.map"]) {
-  await Deno.copyFile(join(output_dir, filename), join(staging_dist_dir, filename));
+for (
+  const filename of [
+    "extension.js",
+    "extension.js.map",
+    "server.js",
+    "server.js.map",
+  ]
+) {
+  await Deno.copyFile(
+    join(output_dir, filename),
+    join(staging_dist_dir, filename),
+  );
 }
-await copy(join(output_dir, "runtime"), join(staging_dir, "runtime"), { overwrite: true });
-await Deno.copyFile(join(package_dir, "README.md"), join(staging_dir, "README.md"));
+await copy(join(output_dir, "runtime"), join(staging_dist_dir, "runtime"), {
+  overwrite: true,
+});
+await Deno.copyFile(
+  join(package_dir, "README.md"),
+  join(staging_dir, "README.md"),
+);
 
 const manifest = JSON.parse(
   await Deno.readTextFile(join(package_dir, "package.json")),
 );
 await Deno.writeTextFile(
   join(staging_dir, "package.json"),
-  `${JSON.stringify(manifest, null, 2)}\n`,
+  `${JSON.stringify(include_packaged_node_modules(manifest), null, 2)}\n`,
 );
 
 const install_result = await new Deno.Command("npm", {
@@ -48,9 +78,16 @@ if (install_result.code !== 0) {
   Deno.exit(install_result.code);
 }
 
+await assert_runtime_dependencies_installed(
+  staging_dir,
+  required_runtime_dependencies,
+);
+
 const output_name = `${manifest.name}-${manifest.version}.vsix`;
 await Deno.mkdir(output_dir, { recursive: true });
-await Deno.remove(join(output_dir, output_name), { recursive: true }).catch(() => undefined);
+await Deno.remove(join(output_dir, output_name), { recursive: true }).catch(
+  () => undefined,
+);
 const package_result = await new Deno.Command("npx", {
   args: [
     "--yes",
@@ -69,4 +106,30 @@ await Deno.remove(staging_dir, { recursive: true }).catch(() => undefined);
 
 if (package_result.code !== 0) {
   Deno.exit(package_result.code);
+}
+
+function include_packaged_node_modules(manifest: Record<string, unknown>) {
+  const files = Array.isArray(manifest.files)
+    ? manifest.files.filter((value): value is string =>
+      typeof value === "string"
+    )
+    : [];
+
+  if (!files.includes("node_modules")) {
+    files.push("node_modules");
+  }
+
+  return {
+    ...manifest,
+    files,
+  };
+}
+
+async function assert_runtime_dependencies_installed(
+  root: string,
+  dependencies: string[],
+) {
+  for (const dependency of dependencies) {
+    await Deno.stat(join(root, "node_modules", dependency, "package.json"));
+  }
 }

--- a/modules/svelte-effect-runtime-vscode-extension/.vscodeignore
+++ b/modules/svelte-effect-runtime-vscode-extension/.vscodeignore
@@ -1,8 +1,7 @@
 **/.git/**
 **/.DS_Store
 scripts/**
-extension.cjs
-server.cjs
-patch-language-server.cjs
+extension.js
+server.js
+patch-language-server.js
 !dist/**
-!runtime/**

--- a/modules/svelte-effect-runtime-vscode-extension/extension.ts
+++ b/modules/svelte-effect-runtime-vscode-extension/extension.ts
@@ -7,7 +7,7 @@ const STATE_PREVIOUS_PATH = "svelteEffectRuntime.previousLsPath";
 const STATE_MANAGED_PATH = "svelteEffectRuntime.managedLsPath";
 
 export async function activate(context: vscode.ExtensionContext) {
-  const server_path = context.asAbsolutePath("dist/server.cjs");
+  const server_path = context.asAbsolutePath("dist/server.js");
 
   context.subscriptions.push(
     vscode.commands.registerCommand(
@@ -46,10 +46,11 @@ async function configure_language_server(
 ) {
   const svelte_config = vscode.workspace.getConfiguration("svelte");
   const current_path = svelte_config.get<string | undefined>(TARGET_KEY);
-  const managed_path = context.globalState.get<string | undefined>(STATE_MANAGED_PATH);
+  const managed_path = context.globalState.get<string | undefined>(
+    STATE_MANAGED_PATH,
+  );
 
-  const can_auto_configure =
-    !current_path ||
+  const can_auto_configure = !current_path ||
     current_path === managed_path ||
     current_path === server_path;
 
@@ -75,7 +76,9 @@ async function configure_language_server(
 
 async function disable_language_server(context: vscode.ExtensionContext) {
   const svelte_config = vscode.workspace.getConfiguration("svelte");
-  const previous_path = context.globalState.get<string | undefined>(STATE_PREVIOUS_PATH);
+  const previous_path = context.globalState.get<string | undefined>(
+    STATE_PREVIOUS_PATH,
+  );
 
   await svelte_config.update(
     TARGET_KEY,

--- a/modules/svelte-effect-runtime-vscode-extension/package.json
+++ b/modules/svelte-effect-runtime-vscode-extension/package.json
@@ -5,8 +5,9 @@
   "version": "1.2.2",
   "publisher": "barekey",
   "license": "BSD-3-Clause",
+  "type": "module",
   "engines": {
-    "vscode": "^1.95.0"
+    "vscode": "^1.100.0"
   },
   "categories": [
     "Programming Languages",
@@ -22,10 +23,10 @@
   ],
   "files": [
     "dist",
-    "runtime",
+    "node_modules",
     "README.md"
   ],
-  "main": "./dist/extension.cjs",
+  "main": "./dist/extension.js",
   "contributes": {
     "commands": [
       {

--- a/modules/svelte-effect-runtime/vite.ts
+++ b/modules/svelte-effect-runtime/vite.ts
@@ -5,7 +5,7 @@ import {
 import { createRequire } from "node:module";
 import { dirname, resolve } from "node:path";
 import process from "node:process";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import type { Plugin } from "vite";
 import {
   effectPreprocess,
@@ -60,12 +60,14 @@ function resolve_runtime_internal_path(
     ? source_relative_path
     : dist_relative_path;
 
-  return new URL(relative_path, import.meta.url).pathname;
+  return fileURLToPath(new URL(relative_path, import.meta.url));
 }
 
 function resolve_kit_internal_runtime_path(relative_path: string): string {
   const runtime_require = createRequire(resolve(process.cwd(), "package.json"));
-  const kit_package_path = runtime_require.resolve("@sveltejs/kit/package.json");
+  const kit_package_path = runtime_require.resolve(
+    "@sveltejs/kit/package.json",
+  );
   const kit_root = dirname(kit_package_path);
 
   return pathToFileURL(resolve(kit_root, relative_path)).href;
@@ -104,18 +106,30 @@ function create_remote_runtime_module_code(): string {
   return `
 import * as devalue from "devalue";
 import { base, app_dir } from "$app/paths/internal/client";
-import { query as native_query, query_batch as native_query_batch } from ${JSON.stringify(kit_query_module_path)};
-import { command as native_command } from ${JSON.stringify(kit_command_module_path)};
+import { query as native_query, query_batch as native_query_batch } from ${
+    JSON.stringify(kit_query_module_path)
+  };
+import { command as native_command } from ${
+    JSON.stringify(kit_command_module_path)
+  };
 import { form as native_form } from ${JSON.stringify(kit_form_module_path)};
-import { prerender as native_prerender } from ${JSON.stringify(kit_prerender_module_path)};
+import { prerender as native_prerender } from ${
+    JSON.stringify(kit_prerender_module_path)
+  };
 import {
   apply_refreshes,
   get_remote_request_headers,
   remote_request
 } from ${JSON.stringify(kit_shared_module_path)};
-import { app, invalidateAll, _goto } from ${JSON.stringify(kit_client_module_path)};
-import { BINARY_FORM_CONTENT_TYPE, serialize_binary_form } from ${JSON.stringify(kit_form_utils_module_path)};
-import { stringify_remote_arg } from ${JSON.stringify(kit_shared_runtime_module_path)};
+import { app, invalidateAll, _goto } from ${
+    JSON.stringify(kit_client_module_path)
+  };
+import { BINARY_FORM_CONTENT_TYPE, serialize_binary_form } from ${
+    JSON.stringify(kit_form_utils_module_path)
+  };
+import { stringify_remote_arg } from ${
+    JSON.stringify(kit_shared_runtime_module_path)
+  };
 import {
   create_remote_command_adapter,
   create_remote_form_adapter,
@@ -150,7 +164,8 @@ export const form = create_remote_form_adapter(native_form, decode_payload, {
 export function sveltekitEffectRuntime(
   options: SveltekitEffectRuntimeOptions = {},
 ): Plugin {
-  const remote_module_id = options.remoteModuleId ?? "\0svelte-effect-runtime:remote";
+  const remote_module_id = options.remoteModuleId ??
+    "\0svelte-effect-runtime:remote";
 
   return {
     name: "svelte-effect-runtime-remote",


### PR DESCRIPTION
## Summary
- convert the VS Code extension package to ESM output and point the manifest at bundled .js entries
- keep the packaged svelte-language-server dependency inside the VSIX and preserve runtime assets during packaging
- make the build scripts work cleanly across Windows path handling and without symlink privileges

## Verification
- deno task package:extension

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Converted the VS Code extension and VSIX packaging to ESM and made builds Windows-friendly. The VSIX now includes required runtime and the `svelte-language-server` for offline use.

- **Refactors**
  - Switched extension/server output to ESM (`dist/extension.js`, `dist/server.js`) and set `package.json` `main` + `"type": "module"`.
  - VSIX now packages runtime under `dist/runtime` and `node_modules/svelte-language-server`; packaging verifies runtime deps.
  - Replaced symlinks with copy-based staging and improved path handling; updated `.vscodeignore` and bumped VS Code engine to `^1.100.0`.

- **Migration**
  - Requires VS Code 1.100.0+.
  - Build and test: run `deno task package:extension`, then install the generated `.vsix` in VS Code.

<sup>Written for commit a01e3c67a4381192027d9b2409c2d0ca1c95d2b2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

