### PR TITLE
Bump release version to 1.2.4

### DIFF
--- a/modules/svelte-effect-runtime-language-server/package.json
+++ b/modules/svelte-effect-runtime-language-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "svelte-effect-runtime-language-server",
   "private": true,
-  "version": "1.2.3",
+  "version": "1.2.4",
   "license": "BSD-3-Clause",
   "type": "commonjs",
   "main": "./dist/server.cjs",

--- a/modules/svelte-effect-runtime-vscode-extension/package.json
+++ b/modules/svelte-effect-runtime-vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "svelte-effect-runtime-vscode",
   "displayName": "Svelte Effect Runtime",
   "description": "Cursor/VS Code integration for svelte-effect-runtime grammar-aware Svelte language support.",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "publisher": "barekey",
   "license": "BSD-3-Clause",
   "type": "module",

--- a/modules/svelte-effect-runtime/deno.json
+++ b/modules/svelte-effect-runtime/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@barekey/svelte-effect-runtime",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "license": "BSD-3-Clause",
   "exports": {
     ".": "./mod.ts",

--- a/modules/svelte-effect-runtime/package-lock.json
+++ b/modules/svelte-effect-runtime/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "svelte-effect-runtime",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "svelte-effect-runtime",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "license": "BSD-3-Clause",
       "dependencies": {
         "devalue": "^5.5.0",

--- a/modules/svelte-effect-runtime/package.json
+++ b/modules/svelte-effect-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte-effect-runtime",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Client-side Effect runtime support for Svelte <script> blocks.",
   "license": "BSD-3-Clause",
   "type": "module",


### PR DESCRIPTION
## Summary
- bump the runtime package to 1.2.4
- bump the language server and VSIX package versions to 1.2.4
- keep the committed JSR metadata in sync so the release workflow can publish a fresh release

## Testing
- not run (version metadata only)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update all runtime and tooling packages to version 1.2.4 to prepare the release and keep JSR metadata in sync for publishing. Bumps `@barekey/svelte-effect-runtime`, `svelte-effect-runtime`, `svelte-effect-runtime-language-server`, and `svelte-effect-runtime-vscode` (including lockfile).

<sup>Written for commit c9f2398c593746fde0349345e1b8b4db900b8c07. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

