### PR TITLE
Release 1.3.1: fix v4 ServerRuntime typing and dev-server $app regression

### DIFF
--- a/modules/svelte-effect-runtime-language-server/package.json
+++ b/modules/svelte-effect-runtime-language-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "svelte-effect-runtime-language-server",
   "private": true,
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "BSD-3-Clause",
   "type": "commonjs",
   "main": "./dist/server.cjs",

--- a/modules/svelte-effect-runtime-vscode-extension/package.json
+++ b/modules/svelte-effect-runtime-vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "svelte-effect-runtime-vscode",
   "displayName": "Svelte Effect Runtime",
   "description": "Cursor/VS Code integration for svelte-effect-runtime grammar-aware Svelte language support.",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "publisher": "barekey",
   "license": "BSD-3-Clause",
   "type": "module",

--- a/modules/svelte-effect-runtime/deno.json
+++ b/modules/svelte-effect-runtime/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@barekey/svelte-effect-runtime",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "BSD-3-Clause",
   "exports": {
     ".": "./mod.ts",

--- a/modules/svelte-effect-runtime/package.json
+++ b/modules/svelte-effect-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte-effect-runtime",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Client-side Effect runtime support for Svelte <script> blocks.",
   "license": "BSD-3-Clause",
   "type": "module",

--- a/modules/svelte-effect-runtime/v4/root-node.ts
+++ b/modules/svelte-effect-runtime/v4/root-node.ts
@@ -1,4 +1,4 @@
-import * as Server_module from "$/v4/server.ts";
+import type * as Server_module from "$/v4/server.ts";
 
 export * from "$/v4/mod.ts";
 export type * from "$/v4/server.ts";
@@ -10,50 +10,48 @@ export { effect } from "$/v4/effect.ts";
  *
  * @see https://ser.barekey.dev/content/remote-functions/query
  */
-export const Query: typeof Server_module.Query = Server_module.Query;
+export declare const Query: typeof Server_module.Query;
 /**
  * Define a write-oriented remote function that returns an `Effect` on the
  * client.
  *
  * @see https://ser.barekey.dev/content/remote-functions/command
  */
-export const Command: typeof Server_module.Command = Server_module.Command;
+export declare const Command: typeof Server_module.Command;
 /**
  * Define a remote form handler that maps submitted data into an Effect
  * program.
  *
  * @see https://ser.barekey.dev/content/remote-functions/form
  */
-export const Form: typeof Server_module.Form = Server_module.Form;
+export declare const Form: typeof Server_module.Form;
 /**
  * Define a prerenderable remote function backed by an Effect program.
  *
  * @see https://ser.barekey.dev/content/remote-functions/prerender
  */
-export const Prerender: typeof Server_module.Prerender = Server_module.Prerender;
+export declare const Prerender: typeof Server_module.Prerender;
 /**
  * Effect `Context.Tag` for the current SvelteKit `RequestEvent`.
  *
  * @see https://ser.barekey.dev/content/runtimes/server
  */
-export const RequestEvent: typeof Server_module.RequestEvent =
-  Server_module.RequestEvent;
+export declare const RequestEvent: typeof Server_module.RequestEvent;
 /**
  * Server-side runtime builder used to provide long-lived Effect services to
  * remote functions.
  *
  * @see https://ser.barekey.dev/content/reference/server-runtime
  */
-export const ServerRuntime: typeof Server_module.ServerRuntime =
-  Server_module.ServerRuntime;
+export declare const ServerRuntime: typeof Server_module.ServerRuntime;
 /**
  * Build a devalue transport table from Effect schemas so remote payloads can
  * round-trip custom data across the client/server boundary.
  *
  * @see https://ser.barekey.dev/content/reference/transport
  */
-export const create_effect_transport: typeof Server_module.create_effect_transport =
-  Server_module.create_effect_transport;
+export declare const create_effect_transport:
+  typeof Server_module.create_effect_transport;
 /**
  * Resolve the active server runtime, lazily creating a default empty runtime
  * when no explicit one has been registered.
@@ -61,6 +59,5 @@ export const create_effect_transport: typeof Server_module.create_effect_transpo
  * @internal Internal - do not use.
  * @see https://ser.barekey.dev/content/reference/server-runtime
  */
-export const get_server_runtime_or_throw:
-  typeof Server_module.get_server_runtime_or_throw =
-    Server_module.get_server_runtime_or_throw;
+export declare const get_server_runtime_or_throw:
+  typeof Server_module.get_server_runtime_or_throw;

--- a/modules/svelte-effect-runtime/v4/server.ts
+++ b/modules/svelte-effect-runtime/v4/server.ts
@@ -44,7 +44,47 @@ export type RemoteForm<Input extends RemoteFormInput | void, Output> =
 
 type OptionalArgument<Input> = undefined extends Input ? Input | void : Input;
 
-type RuntimeOperator = (self: unknown) => unknown;
+type RuntimeOperator = (
+  self: Layer_type.Layer<unknown, unknown, unknown>,
+) => Layer_type.Layer<unknown, unknown, unknown>;
+
+type RuntimeSeedLayer<Requirements> = Layer_type.Layer<
+  Requirements,
+  never,
+  Requirements
+>;
+
+type ProvidedBy<Op> = Op extends (
+  self: RuntimeSeedLayer<infer Requirements>,
+) => Layer_type.Layer<unknown, unknown, infer Incoming>
+  ? Exclude<Requirements, Incoming>
+  : never;
+
+type ProvidedByAll<Ops extends ReadonlyArray<RuntimeOperator>> = Ops extends
+  readonly [infer Head, ...infer Tail] ?
+    | ProvidedBy<Head>
+    | ProvidedByAll<Extract<Tail, ReadonlyArray<RuntimeOperator>>>
+  : never;
+
+type ApplyOperator<Seed, Op> = Op extends (self: Seed) => infer Out ? Out
+  : never;
+
+type ApplyOperators<
+  Seed,
+  Ops extends ReadonlyArray<RuntimeOperator>,
+> = Ops extends readonly [infer Head, ...infer Tail] ? ApplyOperators<
+    ApplyOperator<Seed, Head>,
+    Extract<Tail, ReadonlyArray<RuntimeOperator>>
+  >
+  : Seed;
+
+type FinalRuntimeLayer<Ops extends ReadonlyArray<RuntimeOperator>> =
+  ApplyOperators<RuntimeSeedLayer<ProvidedByAll<Ops>>, Ops> extends infer Out
+    ? Out extends Layer_type.Layer<unknown, unknown, infer Incoming>
+      ? [Incoming] extends [never] ? Out
+      : never
+    : never
+    : never;
 
 type SchemaInput<SchemaType extends EffectSchemaLike> = SchemaType extends
   { readonly Encoded: infer Input } ? Input
@@ -135,7 +175,7 @@ export interface ServerRuntimeSeed {
   pipe(): Layer_type.Layer<never>;
   pipe<const Ops extends readonly [RuntimeOperator, ...Array<RuntimeOperator>]>(
     ...ops: Ops
-  ): unknown;
+  ): FinalRuntimeLayer<Ops>;
   make(): void;
   make<const Ops extends readonly [RuntimeOperator, ...Array<RuntimeOperator>]>(
     ...ops: Ops


### PR DESCRIPTION
## Summary
- Fix `ServerRuntime.make(Layer.provide(X))` type error in v4 (#10) by porting v3's `RuntimeOperator` / `FinalRuntimeLayer` type machinery.
- Fix dev-server startup failure `Cannot find package '$app'` when importing from `svelte-effect-runtime/v4` (#9) by turning v4/root-node.ts' server-module re-exports into `declare const` ambient stubs (matching v3). Vite's plugin still rewrites the specifier to the real `/v4/_server` entry inside `.remote.ts`, so server-side execution is unaffected.
- Bump `svelte-effect-runtime`, `svelte-effect-runtime-language-server`, `svelte-effect-runtime-vscode-extension`, and `deno.json` to 1.3.1.

## Verification
Reproduced end-to-end in `smokes/testeffect-v4` (SvelteKit + `effect@4.0.0-beta.51` + `experimental.remoteFunctions`):

- `svelte-check`: 0 errors / 0 warnings on a `hooks.server.ts` containing `ServerRuntime.make(Layer.provide(GreeterService.layer))` — confirms #10 fix.
- `npm run dev` starts cleanly (no `$app` resolution failure) and the root page SSRs successfully with `run_remote_effect:success { value: 'hello world from v4 effect runtime' }` in the server log — confirms #9 fix and that remote Effects still execute against a Layer-provided service.

## Test plan
- [ ] CI: runtime checks pass on `release/1.3.1`
- [ ] CI: language-server checks pass
- [ ] CI: vscode-extension checks pass
- [ ] Merge to master triggers `release.yml` and publishes 1.3.1 to npm / JSR / OpenVSX

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes v4 `ServerRuntime` typing and a dev-server `$app` resolution regression. Restores clean dev startup and allows `ServerRuntime.make(Layer.provide(...))` to type-check in v4.

- **Bug Fixes**
  - Port v3 `RuntimeOperator`/`FinalRuntimeLayer` typing to v4 so `ServerRuntime.make(Layer.provide(X))` type-checks.
  - Change v4 `root-node.ts` server re-exports to ambient `declare const` stubs to avoid `$app` resolution during dev; Vite still rewrites to the real server entry at runtime.

- **Dependencies**
  - Bump `svelte-effect-runtime`, `svelte-effect-runtime-language-server`, `svelte-effect-runtime-vscode-extension`, and `deno.json` to `1.3.1`.

<sup>Written for commit 358788e150d4921ca085958f77cc0fc307c61d48. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

