### PR TITLE
Fix form proxy descriptor inspection

### DIFF
--- a/modules/svelte-effect-runtime-language-server/package.json
+++ b/modules/svelte-effect-runtime-language-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "svelte-effect-runtime-language-server",
   "private": true,
-  "version": "1.3.1",
+  "version": "1.3.2",
   "license": "BSD-3-Clause",
   "type": "commonjs",
   "main": "./dist/server.cjs",

--- a/modules/svelte-effect-runtime-vscode-extension/package.json
+++ b/modules/svelte-effect-runtime-vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "svelte-effect-runtime-vscode",
   "displayName": "Svelte Effect Runtime",
   "description": "Cursor/VS Code integration for svelte-effect-runtime grammar-aware Svelte language support.",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "publisher": "barekey",
   "license": "BSD-3-Clause",
   "type": "module",

--- a/modules/svelte-effect-runtime/deno.json
+++ b/modules/svelte-effect-runtime/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@barekey/svelte-effect-runtime",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "license": "BSD-3-Clause",
   "exports": {
     ".": "./mod.ts",

--- a/modules/svelte-effect-runtime/package.json
+++ b/modules/svelte-effect-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte-effect-runtime",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Client-side Effect runtime support for Svelte <script> blocks.",
   "license": "BSD-3-Clause",
   "type": "module",

--- a/modules/svelte-effect-runtime/tests/shared/register-smoke-behaviors.ts
+++ b/modules/svelte-effect-runtime/tests/shared/register-smoke-behaviors.ts
@@ -256,6 +256,101 @@ export default defineConfig({
   };
 }
 
+function create_kit_form_descriptor_fixture(
+  variant: BuildVariant,
+): Record<string, string> {
+  return {
+    "package.json": JSON.stringify(
+      {
+        name: `ser-kit-form-descriptor-${variant.name}`,
+        private: true,
+        type: "module",
+      },
+      null,
+      2,
+    ),
+    "src/app.html": `<!doctype html>
+<html lang="en">
+  <head>%sveltekit.head%</head>
+  <body>
+    <div style="display: contents">%sveltekit.body%</div>
+  </body>
+</html>
+`,
+    "src/routes/+layout.ts": `export const prerender = true;`,
+    "src/routes/+page.server.ts": `import { oauth_remote } from "./oauth.remote";
+
+export function load() {
+  const descriptor = Object.getOwnPropertyDescriptor(oauth_remote, "native");
+
+  return {
+    configurable: descriptor?.configurable ?? null,
+    enumerable: descriptor?.enumerable ?? null,
+    writable: "writable" in (descriptor ?? {})
+      ? (descriptor as PropertyDescriptor).writable ?? null
+      : null,
+  };
+}
+`,
+    "src/routes/+page.svelte": `<script lang="ts">
+  let { data } = $props<{
+    data: {
+      configurable: boolean | null;
+      enumerable: boolean | null;
+      writable: boolean | null;
+    };
+  }>();
+</script>
+
+<h1>form descriptor smoke</h1>
+<p>{String(data.configurable)} / {String(data.enumerable)} / {String(data.writable)}</p>
+`,
+    "src/routes/oauth.remote.ts": `import * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
+import { Form } from "${variant.runtimeImport}";
+
+const OAuthInput = Schema.Struct({
+  provider: Schema.String,
+});
+
+export const oauth_remote = Form(OAuthInput, ({ data }) =>
+  Effect.succeed({
+    provider: data.provider,
+    redirectTo: "/auth/" + data.provider,
+  })
+);
+`,
+    "svelte.config.js": `import adapter from "@sveltejs/adapter-static";
+import { effect_preprocess } from "${variant.preprocessImport}";
+
+/** @type {import("@sveltejs/kit").Config} */
+const config = {
+  preprocess: [
+    effect_preprocess({
+      runtimeModuleId: ${JSON.stringify(variant.runtimeImport)},
+    }),
+  ],
+  kit: {
+    adapter: adapter(),
+    experimental: {
+      remoteFunctions: true,
+    },
+  },
+};
+
+export default config;
+`,
+    "vite.config.mjs": `import { sveltekit } from "@sveltejs/kit/vite";
+import { sveltekit_effect_runtime } from "${variant.viteImport}";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [sveltekit_effect_runtime(), sveltekit()],
+});
+`,
+  };
+}
+
 async function build_fixture(
   fixture_root: string,
   config_file: string,
@@ -298,6 +393,24 @@ export function register_smoke_behaviors(harness: VersionHarness): void {
           await writeFixtureTree(
             fixture_root,
             create_kit_fixture(variant),
+          );
+          await install_smoke_dependencies(fixture_root, harness, tarball);
+          await build_fixture(fixture_root, "vite.config.mjs");
+        });
+      },
+    );
+
+    Deno.test(
+      `[${harness.label}] SvelteKit Form fixtures survive native descriptor inspection for ${variant.name}`,
+      async () => {
+        await with_package_build_lock(async () => {
+          const fixture_root = await makeTempWorkspace(
+            `kit-form-descriptor-${variant.name}-`,
+          );
+          const tarball = await pack_runtime_package();
+          await writeFixtureTree(
+            fixture_root,
+            create_kit_form_descriptor_fixture(variant),
           );
           await install_smoke_dependencies(fixture_root, harness, tarball);
           await build_fixture(fixture_root, "vite.config.mjs");

--- a/modules/svelte-effect-runtime/v3/server.ts
+++ b/modules/svelte-effect-runtime/v3/server.ts
@@ -666,15 +666,6 @@ function create_native_wrapper(value: object) {
       return property === "native" || Reflect.has(target, property);
     },
     getOwnPropertyDescriptor(target, property) {
-      if (property === "native") {
-        return {
-          configurable: true,
-          enumerable: false,
-          value,
-          writable: false,
-        };
-      }
-
       return Reflect.getOwnPropertyDescriptor(target, property);
     },
   });


### PR DESCRIPTION
## Summary
- fix the remote Form proxy so `Object.getOwnPropertyDescriptor(..., native)` no longer violates proxy invariants
- add a SvelteKit smoke regression that exercises descriptor inspection on Form wrappers for v3 and v4
- bump published package versions to `1.3.2`

## Testing
- `deno test --node-modules-dir=auto -A tests/v3/server-runtime.behavior.test.ts tests/v4/server-runtime.behavior.test.ts tests/v3/smoke.behavior.test.ts tests/v4/smoke.behavior.test.ts`

Fixes #12

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Form proxy descriptor inspection for "native" so it no longer violates JS proxy invariants. Adds a SvelteKit smoke test and bumps packages to 1.3.2. Fixes #12.

- **Bug Fixes**
  - Remove the custom descriptor for "native" in the v3 server Form proxy to comply with Proxy invariants during `Object.getOwnPropertyDescriptor`.
  - Add a SvelteKit smoke test that inspects the "native" descriptor on Form wrappers across runtime v3 and v4 to prevent regressions.

- **Dependencies**
  - Bump `svelte-effect-runtime`, `@barekey/svelte-effect-runtime`, `svelte-effect-runtime-language-server`, and `svelte-effect-runtime-vscode` to 1.3.2.

<sup>Written for commit 40280bafa2e3e406f6cf42eb9baadb3e7a8a49f0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

