### PR TITLE
chore: fix JSR score issues (#8)

### DIFF
--- a/modules/svelte-effect-runtime/internal/remote-shared.ts
+++ b/modules/svelte-effect-runtime/internal/remote-shared.ts
@@ -1,56 +1,132 @@
+/**
+ * Marker property name placed on serialized `RemoteFailure` envelopes so the
+ * client adapters can recognise server-produced failure payloads.
+ *
+ * @internal Internal - do not use.
+ */
 export const EFFECT_REMOTE_ERROR_MARKER = "__svelte_effect_remote__";
+/**
+ * Well-known symbol used to attach a payload decoder to a remote function,
+ * enabling the client to reconstruct typed domain errors from wire data.
+ *
+ * @internal Internal - do not use.
+ */
 export const REMOTE_ERROR_DECODER = Symbol.for(
   "svelte-effect-runtime/remote-error-decoder",
 );
 
+/**
+ * A single validation problem surfaced by a remote form or schema check.
+ * Mirrors SvelteKit's `invalid()` issue shape.
+ */
 export interface FormIssue {
+  /** Human-readable description of the failure at {@link FormIssue.path}. */
   readonly message: string;
+  /** Field path (dot or array-index segments) the issue applies to. */
   readonly path: ReadonlyArray<string | number>;
 }
 
+/**
+ * Typed error produced by `invalid.form(...)` / `invalid.<field>(...)` helpers
+ * inside a `Form` handler. Carries the collected `FormIssue`s to surface to
+ * the browser.
+ */
 export interface FormError<SchemaType = unknown> {
+  /** Discriminator identifying this as a form error. */
   readonly _tag: "FormError";
+  /** Issues produced by the handler, one per failed field. */
   readonly issues: ReadonlyArray<FormIssue>;
+  /**
+   * Phantom reference to the originating schema. Used purely for type
+   * inference of field helpers.
+   */
   readonly _schema?: SchemaType | undefined;
 }
 
+/**
+ * Remote failure carrying a domain error defined by the server-side
+ * `Effect.fail(...)`. Preserves the original error value across the wire.
+ */
 export interface RemoteDomainError<ErrorType = unknown> {
+  /** Discriminator identifying this variant of `RemoteFailure`. */
   readonly _tag: "RemoteDomainError";
+  /** The original typed error value produced on the server. */
   readonly cause: ErrorType;
+  /** HTTP status code associated with the failure. */
   readonly status: number;
 }
 
+/**
+ * Remote failure emitted when request validation (schema or form) rejects the
+ * payload. Always surfaces as an HTTP `400`.
+ */
 export interface RemoteValidationError {
+  /** Discriminator identifying this variant of `RemoteFailure`. */
   readonly _tag: "RemoteValidationError";
+  /** Raw response body returned alongside the failure, when available. */
   readonly body?: unknown;
+  /** Validation issues, keyed by field path. */
   readonly issues: ReadonlyArray<FormIssue>;
+  /** HTTP status code - always `400` for validation errors. */
   readonly status: number;
 }
 
+/**
+ * Remote failure for HTTP-level errors returned by the server that do not map
+ * onto a typed domain error or validation failure.
+ */
 export interface RemoteHttpError {
+  /** Discriminator identifying this variant of `RemoteFailure`. */
   readonly _tag: "RemoteHttpError";
+  /** Parsed response body, if any. */
   readonly body?: unknown;
+  /** Original thrown value captured while handling the response. */
   readonly cause: unknown;
+  /** HTTP status code reported by the response. */
   readonly status: number;
 }
 
+/**
+ * Remote failure for transport-level breakages (network errors, decoding
+ * failures). Does not carry an HTTP status.
+ */
 export interface RemoteTransportError {
+  /** Discriminator identifying this variant of `RemoteFailure`. */
   readonly _tag: "RemoteTransportError";
+  /** Raw body captured when the transport failure was detected, if any. */
   readonly body?: unknown;
+  /** Underlying error value - usually a `TypeError` or `DOMException`. */
   readonly cause: unknown;
 }
 
+/**
+ * Union of every failure shape a remote function can produce on the client.
+ * Use `_tag` to narrow before handling.
+ */
 export type RemoteFailure<ErrorType = unknown> =
   | RemoteDomainError<ErrorType>
   | RemoteValidationError
   | RemoteHttpError
   | RemoteTransportError;
 
+/**
+ * Wire shape of a serialised remote failure envelope that the server embeds
+ * in its response body.
+ *
+ * @internal Internal - do not use.
+ */
 export interface SerializedRemoteFailureEnvelope {
+  /** Marker flag; always `true`. */
   readonly [EFFECT_REMOTE_ERROR_MARKER]: true;
+  /** `devalue.stringify`-encoded payload for the failure value. */
   readonly encoded: string;
 }
 
+/**
+ * Construct a {@link FormError} from one or more {@link FormIssue}s.
+ *
+ * @internal Internal - do not use.
+ */
 export function create_form_error<SchemaType = unknown>(
   ...issues: Array<FormIssue>
 ): FormError<SchemaType> {
@@ -60,6 +136,11 @@ export function create_form_error<SchemaType = unknown>(
   };
 }
 
+/**
+ * Build a {@link RemoteDomainError} around a typed server-side error value.
+ *
+ * @internal Internal - do not use.
+ */
 export function create_remote_domain_error<ErrorType = unknown>(
   cause: ErrorType,
   status: number,
@@ -71,6 +152,11 @@ export function create_remote_domain_error<ErrorType = unknown>(
   };
 }
 
+/**
+ * Build a {@link RemoteValidationError} from a list of issues.
+ *
+ * @internal Internal - do not use.
+ */
 export function create_remote_validation_error(
   issues: ReadonlyArray<FormIssue>,
   options: {
@@ -86,6 +172,11 @@ export function create_remote_validation_error(
   };
 }
 
+/**
+ * Build a {@link RemoteHttpError} from an arbitrary thrown value.
+ *
+ * @internal Internal - do not use.
+ */
 export function create_remote_http_error(
   cause: unknown,
   options: {
@@ -101,6 +192,11 @@ export function create_remote_http_error(
   };
 }
 
+/**
+ * Build a {@link RemoteTransportError} from an arbitrary thrown value.
+ *
+ * @internal Internal - do not use.
+ */
 export function create_remote_transport_error(
   cause: unknown,
   body?: unknown,
@@ -112,6 +208,12 @@ export function create_remote_transport_error(
   };
 }
 
+/**
+ * Wrap a pre-encoded failure payload in the marker envelope the client
+ * adapters look for when decoding responses.
+ *
+ * @internal Internal - do not use.
+ */
 export function create_serialized_remote_failure_envelope(
   encoded: string,
 ): SerializedRemoteFailureEnvelope {
@@ -121,6 +223,11 @@ export function create_serialized_remote_failure_envelope(
   };
 }
 
+/**
+ * Type guard for {@link FormError} values.
+ *
+ * @internal Internal - do not use.
+ */
 export function is_form_error(value: unknown): value is FormError {
   return Boolean(
     value &&
@@ -130,6 +237,12 @@ export function is_form_error(value: unknown): value is FormError {
   );
 }
 
+/**
+ * Type guard recognising the marker envelope wrapping an encoded remote
+ * failure payload.
+ *
+ * @internal Internal - do not use.
+ */
 export function is_serialized_remote_failure_envelope(
   value: unknown,
 ): value is SerializedRemoteFailureEnvelope {
@@ -142,6 +255,11 @@ export function is_serialized_remote_failure_envelope(
   );
 }
 
+/**
+ * Type guard for individual {@link FormIssue} values.
+ *
+ * @internal Internal - do not use.
+ */
 export function is_remote_validation_issue(
   value: unknown,
 ): value is FormIssue {

--- a/modules/svelte-effect-runtime/internal/remote-shared.ts
+++ b/modules/svelte-effect-runtime/internal/remote-shared.ts
@@ -58,7 +58,8 @@ export interface RemoteDomainError<ErrorType = unknown> {
 
 /**
  * Remote failure emitted when request validation (schema or form) rejects the
- * payload. Always surfaces as an HTTP `400`.
+ * payload. Defaults to HTTP `400`, but callers may override the status code
+ * when constructing the value.
  */
 export interface RemoteValidationError {
   /** Discriminator identifying this variant of `RemoteFailure`. */
@@ -67,7 +68,7 @@ export interface RemoteValidationError {
   readonly body?: unknown;
   /** Validation issues, keyed by field path. */
   readonly issues: ReadonlyArray<FormIssue>;
-  /** HTTP status code - always `400` for validation errors. */
+  /** HTTP status code for the validation failure, defaulting to `400`. */
   readonly status: number;
 }
 

--- a/modules/svelte-effect-runtime/mod.ts
+++ b/modules/svelte-effect-runtime/mod.ts
@@ -1,1 +1,22 @@
+/**
+ * Main entrypoint for `svelte-effect-runtime`.
+ *
+ * Re-exports the v3 public surface so that plain
+ * `import { ClientRuntime } from "svelte-effect-runtime"` resolves to the
+ * stable default runtime. For explicit version targeting see
+ * `svelte-effect-runtime/v3` and `svelte-effect-runtime/v4`.
+ *
+ * @example
+ * ```ts
+ * import { ClientRuntime, run_component_effect } from "svelte-effect-runtime";
+ * import { Effect } from "effect";
+ *
+ * const runtime = ClientRuntime.make();
+ * run_component_effect(runtime, Effect.log("hello from effect"));
+ * ```
+ *
+ * @see https://ser.barekey.dev/
+ *
+ * @module
+ */
 export * from "$/v3/mod.ts";

--- a/modules/svelte-effect-runtime/server.ts
+++ b/modules/svelte-effect-runtime/server.ts
@@ -1,3 +1,28 @@
+/**
+ * Default server-side entrypoint for `svelte-effect-runtime`.
+ *
+ * Re-exports the v3 remote-function helpers (`Query`, `Command`, `Form`,
+ * `Prerender`), the `ServerRuntime` builder, and the `RequestEvent` service
+ * tag. Consumers normally import this module indirectly: the Vite plugin
+ * rewrites the public runtime specifier to this subpath inside `.remote.ts`
+ * files so the real implementation runs server-side.
+ *
+ * @example
+ * ```ts
+ * import { Query, ServerRuntime } from "svelte-effect-runtime/_server";
+ * import { Effect, Schema } from "effect";
+ *
+ * ServerRuntime.make();
+ *
+ * export const hello = Query(Schema.String, (name) =>
+ *   Effect.succeed(`hello ${name}`)
+ * );
+ * ```
+ *
+ * @see https://ser.barekey.dev/content/reference/server-runtime
+ *
+ * @module
+ */
 import * as Server_module from "$/v3/server.ts";
 
 export type * from "$/v3/server.ts";

--- a/modules/svelte-effect-runtime/v3/client.ts
+++ b/modules/svelte-effect-runtime/v3/client.ts
@@ -21,14 +21,32 @@ interface ProvideEffectRuntimeOptions {
   disposeOnDestroy?: boolean;
 }
 
+/**
+ * Minimal runtime abstraction the client adapters rely on. Implemented by the
+ * Effect `ManagedRuntime` returned from {@link ClientRuntime.make}, but
+ * callers may substitute their own object conforming to this shape.
+ *
+ * @see https://ser.barekey.dev/content/reference/client-runtime
+ */
 export interface EffectRuntime<R = unknown> {
+  /**
+   * Execute an Effect and receive a cancellation token. The optional `onExit`
+   * callback fires with the final `Exit` value once the fiber completes.
+   */
   runCallback<A, E, R2>(
     effect: Effect.Effect<A, E, R2>,
     options?: {
       onExit?: (exit: Exit.Exit<A, E>) => void;
     },
   ): () => void;
+  /**
+   * Execute an Effect and return a Promise that resolves with the success
+   * value or rejects with the propagated failure.
+   */
   runPromise<A, E, R2>(effect: Effect.Effect<A, E, R2>): Promise<A>;
+  /**
+   * Tear down the runtime and release any resources held by its root scope.
+   */
   dispose(): Promise<void>;
 }
 
@@ -42,6 +60,12 @@ export type {
   RemoteValidationError,
 } from "$internal/remote-shared.ts";
 
+/**
+ * Alias for {@link EffectRuntime} exposed as a stable service name used by
+ * generated code and documentation.
+ *
+ * @see https://ser.barekey.dev/content/reference/client-runtime
+ */
 export interface ClientRuntimeService extends EffectRuntime<unknown> {}
 
 type RuntimeSeedLayer<R> = Layer.Layer<R, never, R>;

--- a/modules/svelte-effect-runtime/v3/mod.ts
+++ b/modules/svelte-effect-runtime/v3/mod.ts
@@ -1,3 +1,27 @@
+/**
+ * v3 public entrypoint for `svelte-effect-runtime`.
+ *
+ * Exposes the stable client runtime, lifecycle helpers, and shared remote
+ * error / result types. Import from `svelte-effect-runtime/v3` to pin against
+ * the v3 runtime explicitly; the package default entry (`mod.ts`) re-exports
+ * everything here.
+ *
+ * @example
+ * ```ts
+ * import {
+ *   ClientRuntime,
+ *   run_component_effect,
+ * } from "svelte-effect-runtime/v3";
+ * import { Effect } from "effect";
+ *
+ * const runtime = ClientRuntime.make();
+ * run_component_effect(runtime, Effect.log("hi from v3"));
+ * ```
+ *
+ * @see https://ser.barekey.dev/
+ *
+ * @module
+ */
 export type { EffectPreprocessOptions } from "$/v3/preprocess.ts";
 export type {
   ClientRuntimeService,

--- a/modules/svelte-effect-runtime/v3/server.ts
+++ b/modules/svelte-effect-runtime/v3/server.ts
@@ -1,3 +1,28 @@
+/**
+ * v3 server-side entrypoint for `svelte-effect-runtime`.
+ *
+ * Implements the Effect-aware wrappers around SvelteKit's remote-function
+ * primitives (`query`, `command`, `form`, `prerender`) together with the
+ * `ServerRuntime` builder and the `RequestEvent` service tag. Applications
+ * rarely import this module directly — the Vite plugin rewrites imports
+ * inside `.remote.ts` files to resolve here automatically.
+ *
+ * @example
+ * ```ts
+ * import { Query, ServerRuntime } from "svelte-effect-runtime/v3/_server";
+ * import { Effect, Schema } from "effect";
+ *
+ * ServerRuntime.make();
+ *
+ * export const hello = Query(Schema.String, (name) =>
+ *   Effect.succeed(`hello ${name}`)
+ * );
+ * ```
+ *
+ * @see https://ser.barekey.dev/content/reference/server-runtime
+ *
+ * @module
+ */
 import {
   error as svelte_error,
   invalid as svelte_invalid,
@@ -33,19 +58,39 @@ import {
 
 type EffectSchema = Schema.Schema.Any;
 
+/**
+ * Single entry in a {@link Transport} table. Describes how to encode a value
+ * of type `T` to a wire payload and decode it back.
+ *
+ * @see https://ser.barekey.dev/content/reference/transport
+ */
 export interface Transporter<T = unknown, U = { value: unknown }> {
+  /** Restore the original value from the wire payload. */
   decode: (data: U) => T;
+  /**
+   * Encode the value to a wire payload, or return `false` when this transporter
+   * does not apply to the supplied value.
+   */
   encode: (value: T) => false | U;
 }
 
+/**
+ * Named collection of {@link Transporter}s, passed to devalue so custom types
+ * survive the client/server round-trip.
+ *
+ * @see https://ser.barekey.dev/content/reference/transport
+ */
 export type Transport = Record<string, Transporter>;
 
+/** Alias for SvelteKit's native remote-form input shape. */
 export type RemoteFormInput = SvelteKitRemoteFormInput;
 
+/** SvelteKit's native `query` function signature, re-exported for typing. */
 export type RemoteQueryFunction<Input, Output> = (
   arg: OptionalArgument<Input>,
 ) => Promise<Output>;
 
+/** SvelteKit's native `command` shape, re-exported for typing. */
 export type RemoteCommand<Input, Output> =
   & ((
     arg: OptionalArgument<Input>,
@@ -56,10 +101,12 @@ export type RemoteCommand<Input, Output> =
     readonly pending: number;
   };
 
+/** SvelteKit's native `prerender` function signature, re-exported for typing. */
 export type RemotePrerenderFunction<Input, Output> = (
   arg: OptionalArgument<Input>,
 ) => Promise<Output>;
 
+/** SvelteKit's native `form` shape, re-exported for typing. */
 export type RemoteForm<Input extends RemoteFormInput | void, Output> =
   SvelteKitRemoteForm<Input, Output>;
 
@@ -122,8 +169,16 @@ type FieldHelpers<FormShape, SchemaType> = FormShape extends
   }
   : Record<PropertyKey, never>;
 
+/**
+ * Proxy passed into `Form` handlers for reporting validation issues. Call
+ * `invalid.form(message)` for a top-level issue, or `invalid.<field>(message)`
+ * to attach the issue to a specific field declared in the schema.
+ *
+ * @see https://ser.barekey.dev/content/remote-functions/form
+ */
 export type Invalid<SchemaType = unknown> =
   & {
+    /** Attach a top-level form issue with the supplied message. */
     form: (
       message: string,
     ) => Effect.Effect<never, FormError<SchemaType>, never>;
@@ -133,6 +188,12 @@ export type Invalid<SchemaType = unknown> =
     SchemaType
   >;
 
+/**
+ * Shape of an Effect-returning remote `query`. Callable with the validated
+ * input; exposes the underlying SvelteKit function via `native`.
+ *
+ * @see https://ser.barekey.dev/content/remote-functions/query
+ */
 export type EffectQueryFunction<Input, Output, Error = never> =
   & ((
     arg: OptionalArgument<Input>,
@@ -142,9 +203,17 @@ export type EffectQueryFunction<Input, Output, Error = never> =
     never
   >)
   & {
+    /** Underlying SvelteKit `query` function, for fallback direct usage. */
     native: RemoteQueryFunction<Input, Output>;
   };
 
+/**
+ * Shape of an Effect-returning remote `command`. Callable with the validated
+ * input; exposes the underlying SvelteKit command via `native` and tracks
+ * in-flight submissions through `pending`.
+ *
+ * @see https://ser.barekey.dev/content/remote-functions/command
+ */
 export type EffectCommand<Input, Output, Error = never> =
   & ((
     arg: OptionalArgument<Input>,
@@ -154,10 +223,18 @@ export type EffectCommand<Input, Output, Error = never> =
     never
   >)
   & {
+    /** Underlying SvelteKit `command` function, for fallback direct usage. */
     native: RemoteCommand<Input, Output>;
+    /** Count of currently in-flight invocations of this command. */
     readonly pending: number;
   };
 
+/**
+ * Shape of an Effect-returning remote `prerender` function. Callable with the
+ * validated input; exposes the underlying SvelteKit function via `native`.
+ *
+ * @see https://ser.barekey.dev/content/remote-functions/prerender
+ */
 export type EffectPrerenderFunction<Input, Output, Error = never> =
   & ((
     arg: OptionalArgument<Input>,
@@ -167,15 +244,26 @@ export type EffectPrerenderFunction<Input, Output, Error = never> =
     never
   >)
   & {
+    /** Underlying SvelteKit `prerender` function, for fallback direct usage. */
     native: RemotePrerenderFunction<Input, Output>;
   };
 
+/**
+ * Shape of an Effect-returning remote `form`. Usable anywhere the native
+ * SvelteKit form is; additionally exposes `submit(data)` to run the form
+ * program as an Effect, and `for(...)` to clone the binding for a given
+ * input.
+ *
+ * @see https://ser.barekey.dev/content/remote-functions/form
+ */
 export type EffectForm<
   Input extends RemoteFormInput | void,
   Output,
   Error = never,
 > = RemoteForm<Input, Output> & {
+  /** Underlying SvelteKit `form` object, for fallback direct usage. */
   native: RemoteForm<Input, Output>;
+  /** Submit the form programmatically and receive the result as an Effect. */
   submit(
     data: OptionalArgument<Input>,
   ): Effect.Effect<
@@ -183,12 +271,17 @@ export type EffectForm<
     import("$internal/remote-shared.ts").RemoteFailure<Error>,
     never
   >;
+  /** Clone the form binding for a specific value - mirrors `RemoteForm.for`. */
   for: RemoteForm<Input, Output>["for"] extends
     (...args: infer Args) => infer Result
     ? (...args: Args) => EffectForm<Input, Output, Error>
     : never;
 };
 
+/**
+ * Type of the SvelteKit `RequestEvent` exposed through the {@link RequestEvent}
+ * Effect service.
+ */
 export type RequestEventService = ReturnType<typeof get_native_request_event>;
 
 /**
@@ -612,20 +705,30 @@ export function create_effect_transport<
   );
 }
 
+/**
+ * Overload set for the {@link Query} factory. Supports no-arg, `"unchecked"`,
+ * and Effect.Schema-validated definitions, plus `Query.batch(...)`.
+ *
+ * @see https://ser.barekey.dev/content/remote-functions/query
+ */
 export interface EffectQueryFactory {
+  /** Define a void-input query. */
   <Output, ErrorType, Requirements>(
     fn: () => Effect.Effect<Output, ErrorType, Requirements>,
   ): EffectQueryFunction<void, Output, ErrorType>;
+  /** Define a query that bypasses schema validation. */
   <Input, Output, ErrorType, Requirements>(
     validate: "unchecked",
     fn: (arg: Input) => Effect.Effect<Output, ErrorType, Requirements>,
   ): EffectQueryFunction<Input, Output, ErrorType>;
+  /** Define a query whose input is validated by an Effect.Schema. */
   <SchemaType extends EffectSchema, Output, ErrorType, Requirements>(
     validate: SchemaType,
     fn: (
       arg: SchemaOutput<SchemaType>,
     ) => Effect.Effect<Output, ErrorType, Requirements>,
   ): EffectQueryFunction<SchemaInput<SchemaType>, Output, ErrorType>;
+  /** Define a batched query - mirrors SvelteKit's `query.batch`. */
   batch: typeof query_batch_factory;
 }
 
@@ -790,14 +893,23 @@ const command_impl = (validate_or_fn: unknown, maybe_fn?: unknown): unknown => {
   return create_native_wrapper(native);
 };
 
+/**
+ * Overload set for the {@link Command} factory. Supports no-arg,
+ * `"unchecked"`, and Effect.Schema-validated definitions.
+ *
+ * @see https://ser.barekey.dev/content/remote-functions/command
+ */
 export interface EffectCommandFactory {
+  /** Define a void-input command. */
   <Output, ErrorType, Requirements>(
     fn: () => Effect.Effect<Output, ErrorType, Requirements>,
   ): EffectCommand<void, Output, ErrorType>;
+  /** Define a command that bypasses schema validation. */
   <Input, Output, ErrorType, Requirements>(
     validate: "unchecked",
     fn: (arg: Input) => Effect.Effect<Output, ErrorType, Requirements>,
   ): EffectCommand<Input, Output, ErrorType>;
+  /** Define a command whose input is validated by an Effect.Schema. */
   <SchemaType extends EffectSchema, Output, ErrorType, Requirements>(
     validate: SchemaType,
     fn: (
@@ -858,10 +970,18 @@ const form_impl = (validate_or_fn: unknown, maybe_fn?: unknown): unknown => {
   return create_native_wrapper(native);
 };
 
+/**
+ * Overload set for the {@link Form} factory. Supports no-arg, `"unchecked"`,
+ * and Effect.Schema-validated form handlers.
+ *
+ * @see https://ser.barekey.dev/content/remote-functions/form
+ */
 export interface EffectFormFactory {
+  /** Define a form handler with no input data. */
   <Output, ErrorType, Requirements>(
     fn: () => Effect.Effect<Output, ErrorType, Requirements>,
   ): EffectForm<void, Output, ErrorType>;
+  /** Define a form handler that bypasses schema validation. */
   <Input extends RemoteFormInput, Output, ErrorType, Requirements>(
     validate: "unchecked",
     fn: (
@@ -871,6 +991,7 @@ export interface EffectFormFactory {
       },
     ) => Effect.Effect<Output, ErrorType | FormError, Requirements>,
   ): EffectForm<Input, Output, ErrorType>;
+  /** Define a form handler whose submitted data is validated by a schema. */
   <SchemaType extends EffectSchema, Output, ErrorType, Requirements>(
     validate: SchemaType,
     fn: (
@@ -890,7 +1011,15 @@ export interface EffectFormFactory {
  */
 export const Form = form_impl as unknown as EffectFormFactory;
 
+/**
+ * Overload set for the {@link Prerender} factory. Accepts the same three
+ * validation flavours as the other factories, plus a SvelteKit `options` bag
+ * with `inputs` / `dynamic` flags.
+ *
+ * @see https://ser.barekey.dev/content/remote-functions/prerender
+ */
 export interface EffectPrerenderFactory {
+  /** Define a void-input prerender function. */
   <Output, ErrorType, Requirements>(
     fn: () => Effect.Effect<Output, ErrorType, Requirements>,
     options?: {
@@ -898,6 +1027,7 @@ export interface EffectPrerenderFactory {
       dynamic?: boolean;
     },
   ): EffectPrerenderFunction<void, Output, ErrorType>;
+  /** Define a prerender function that bypasses schema validation. */
   <Input, Output, ErrorType, Requirements>(
     validate: "unchecked",
     fn: (arg: Input) => Effect.Effect<Output, ErrorType, Requirements>,
@@ -906,6 +1036,7 @@ export interface EffectPrerenderFactory {
       dynamic?: boolean;
     },
   ): EffectPrerenderFunction<Input, Output, ErrorType>;
+  /** Define a prerender function whose input is validated by a schema. */
   <SchemaType extends EffectSchema, Output, ErrorType, Requirements>(
     validate: SchemaType,
     fn: (

--- a/modules/svelte-effect-runtime/v4/mod.ts
+++ b/modules/svelte-effect-runtime/v4/mod.ts
@@ -1,3 +1,27 @@
+/**
+ * v4 public entrypoint for `svelte-effect-runtime`.
+ *
+ * Targets Effect v4 (beta) while sharing the underlying client helpers with
+ * v3. Importing from `svelte-effect-runtime/v4` opts into the v4 preprocess /
+ * Vite pipeline and the v4-flavoured server helpers exposed through the
+ * `/v4/_server` subpath.
+ *
+ * @example
+ * ```ts
+ * import {
+ *   ClientRuntime,
+ *   run_component_effect,
+ * } from "svelte-effect-runtime/v4";
+ * import { Effect } from "effect";
+ *
+ * const runtime = ClientRuntime.make();
+ * run_component_effect(runtime, Effect.log("hi from v4"));
+ * ```
+ *
+ * @see https://ser.barekey.dev/
+ *
+ * @module
+ */
 export type { EffectPreprocessOptions } from "$/v4/preprocess.ts";
 export type {
   ClientRuntimeService,

--- a/modules/svelte-effect-runtime/v4/server.ts
+++ b/modules/svelte-effect-runtime/v4/server.ts
@@ -1,3 +1,28 @@
+/**
+ * v4 server-side entrypoint for `svelte-effect-runtime`.
+ *
+ * Provides Effect v4-flavoured remote-function helpers and the updated
+ * `ServerRuntime` builder whose `RuntimeOperator` signature accepts the
+ * v4-style `Layer.provide(...)` operator. Usually consumed indirectly: the
+ * Vite plugin rewrites `svelte-effect-runtime/v4` imports inside `.remote.ts`
+ * to resolve here at build time.
+ *
+ * @example
+ * ```ts
+ * import { Query, ServerRuntime } from "svelte-effect-runtime/v4/_server";
+ * import { Effect, Layer, Schema } from "effect";
+ *
+ * ServerRuntime.make(Layer.provide(MyServiceLayer));
+ *
+ * export const hello = Query(Schema.String, (name) =>
+ *   Effect.succeed(`hello ${name}`)
+ * );
+ * ```
+ *
+ * @see https://ser.barekey.dev/content/reference/server-runtime
+ *
+ * @module
+ */
 import type {
   RemoteForm as SvelteKitRemoteForm,
   RemoteFormInput as SvelteKitRemoteFormInput,
@@ -12,19 +37,39 @@ import {
   make_context_key,
 } from "$internal/effect-compat.ts";
 
+/**
+ * Single entry in a {@link Transport} table. Describes how to encode a value
+ * to a wire payload and decode it back.
+ *
+ * @see https://ser.barekey.dev/content/reference/transport
+ */
 export interface Transporter<T = unknown, U = { value: unknown }> {
+  /** Restore the original value from the wire payload. */
   decode: (data: U) => T;
+  /**
+   * Encode the value to a wire payload, or return `false` when this transporter
+   * does not apply to the supplied value.
+   */
   encode: (value: T) => false | U;
 }
 
+/**
+ * Named collection of {@link Transporter}s used by devalue to round-trip
+ * custom types across the client/server boundary.
+ *
+ * @see https://ser.barekey.dev/content/reference/transport
+ */
 export type Transport = Record<string, Transporter>;
 
+/** Alias for SvelteKit's native remote-form input shape. */
 export type RemoteFormInput = SvelteKitRemoteFormInput;
 
+/** SvelteKit's native `query` function signature, re-exported for typing. */
 export type RemoteQueryFunction<Input, Output> = (
   arg: OptionalArgument<Input>,
 ) => Promise<Output>;
 
+/** SvelteKit's native `command` shape, re-exported for typing. */
 export type RemoteCommand<Input, Output> =
   & ((
     arg: OptionalArgument<Input>,
@@ -35,10 +80,12 @@ export type RemoteCommand<Input, Output> =
     readonly pending: number;
   };
 
+/** SvelteKit's native `prerender` function signature, re-exported for typing. */
 export type RemotePrerenderFunction<Input, Output> = (
   arg: OptionalArgument<Input>,
 ) => Promise<Output>;
 
+/** SvelteKit's native `form` shape, re-exported for typing. */
 export type RemoteForm<Input extends RemoteFormInput | void, Output> =
   SvelteKitRemoteForm<Input, Output>;
 
@@ -102,8 +149,16 @@ type FieldHelpers<FormShape, SchemaType> = FormShape extends
   }
   : Record<PropertyKey, never>;
 
+/**
+ * Proxy passed into v4 `Form` handlers for reporting validation issues. Call
+ * `invalid.form(message)` for a top-level issue, or `invalid.<field>(message)`
+ * to attach the issue to a specific field.
+ *
+ * @see https://ser.barekey.dev/content/remote-functions/form
+ */
 export type Invalid<SchemaType = unknown> =
   & {
+    /** Attach a top-level form issue with the supplied message. */
     form: (
       message: string,
     ) => Effect_type.Effect<never, FormError<SchemaType>, never>;
@@ -113,6 +168,12 @@ export type Invalid<SchemaType = unknown> =
     SchemaType
   >;
 
+/**
+ * v4 shape of an Effect-returning remote `query`. Exposes the underlying
+ * SvelteKit function via `native`.
+ *
+ * @see https://ser.barekey.dev/content/remote-functions/query
+ */
 export type EffectQueryFunction<Input, Output, Error = never> =
   & ((
     arg: OptionalArgument<Input>,
@@ -122,9 +183,16 @@ export type EffectQueryFunction<Input, Output, Error = never> =
     never
   >)
   & {
+    /** Underlying SvelteKit `query` function, for fallback direct usage. */
     native: RemoteQueryFunction<Input, Output>;
   };
 
+/**
+ * v4 shape of an Effect-returning remote `command`. Tracks in-flight
+ * submissions via `pending`.
+ *
+ * @see https://ser.barekey.dev/content/remote-functions/command
+ */
 export type EffectCommand<Input, Output, Error = never> =
   & ((
     arg: OptionalArgument<Input>,
@@ -134,10 +202,17 @@ export type EffectCommand<Input, Output, Error = never> =
     never
   >)
   & {
+    /** Underlying SvelteKit `command` function, for fallback direct usage. */
     native: RemoteCommand<Input, Output>;
+    /** Count of currently in-flight invocations of this command. */
     readonly pending: number;
   };
 
+/**
+ * v4 shape of an Effect-returning remote `prerender` function.
+ *
+ * @see https://ser.barekey.dev/content/remote-functions/prerender
+ */
 export type EffectPrerenderFunction<Input, Output, Error = never> =
   & ((
     arg: OptionalArgument<Input>,
@@ -147,15 +222,24 @@ export type EffectPrerenderFunction<Input, Output, Error = never> =
     never
   >)
   & {
+    /** Underlying SvelteKit `prerender` function, for fallback direct usage. */
     native: RemotePrerenderFunction<Input, Output>;
   };
 
+/**
+ * v4 shape of an Effect-returning remote `form`. Adds `submit(data)` and
+ * `for(...)` on top of the underlying SvelteKit form.
+ *
+ * @see https://ser.barekey.dev/content/remote-functions/form
+ */
 export type EffectForm<
   Input extends RemoteFormInput | void,
   Output,
   Error = never,
 > = RemoteForm<Input, Output> & {
+  /** Underlying SvelteKit `form` object, for fallback direct usage. */
   native: RemoteForm<Input, Output>;
+  /** Submit the form programmatically and receive the result as an Effect. */
   submit(
     data: OptionalArgument<Input>,
   ): Effect_type.Effect<
@@ -163,61 +247,109 @@ export type EffectForm<
     RemoteFailure<Error>,
     never
   >;
+  /** Clone the form binding for a specific value - mirrors `RemoteForm.for`. */
   for: RemoteForm<Input, Output>["for"] extends
     (...args: infer Args) => infer Result
     ? (...args: Args) => EffectForm<Input, Output, Error> & Result
     : never;
 };
 
+/**
+ * v4 type of the SvelteKit `RequestEvent` exposed through the
+ * {@link RequestEvent} Effect service.
+ */
 export type RequestEventService = ReturnType<typeof get_native_request_event>;
 
+/**
+ * Builder shape returned by {@link ServerRuntime} in the v4 runtime. Accepts
+ * v4-style `Layer` operators and installs a singleton `ManagedRuntime`.
+ *
+ * @see https://ser.barekey.dev/content/reference/server-runtime
+ */
 export interface ServerRuntimeSeed {
+  /** Compose operators into a Layer without installing a runtime. */
   pipe(): Layer_type.Layer<never>;
+  /** Compose operators into a Layer without installing a runtime. */
   pipe<const Ops extends readonly [RuntimeOperator, ...Array<RuntimeOperator>]>(
     ...ops: Ops
   ): FinalRuntimeLayer<Ops>;
+  /** Build and install the singleton server runtime. */
   make(): void;
+  /** Build and install the singleton server runtime. */
   make<const Ops extends readonly [RuntimeOperator, ...Array<RuntimeOperator>]>(
     ...ops: Ops
   ): void;
 }
 
+/**
+ * Subset of `ManagedRuntime` surface used by generated v4 server wrappers.
+ *
+ * @internal Internal - do not use.
+ */
 export interface EffectManagedRuntime {
+  /** Execute an Effect and resolve with its raw `Exit`. */
   runPromiseExit<A, E, R>(
     effect: Effect_type.Effect<A, E, R>,
   ): Promise<unknown>;
+  /** Tear down the runtime and release its root scope. */
   dispose(): Promise<void>;
 }
 
+/**
+ * Signature of `Query.batch` in the v4 runtime - kept loosely typed because
+ * the v4 server-side implementation delegates to the v3 batch factory.
+ *
+ * @see https://ser.barekey.dev/content/remote-functions/query
+ */
 export interface EffectQueryBatchFactory {
+  /** Build a batched query from validator + handler arguments. */
   (...args: Array<unknown>): unknown;
 }
 
+/**
+ * v4 overload set for the {@link Query} factory. Mirrors
+ * {@link import("$/v3/server.ts").EffectQueryFactory} using v4 schema-like
+ * inference.
+ *
+ * @see https://ser.barekey.dev/content/remote-functions/query
+ */
 export interface EffectQueryFactory {
+  /** Define a void-input query. */
   <Output, Error, Requirements>(
     fn: () => Effect_type.Effect<Output, Error, Requirements>,
   ): EffectQueryFunction<void, Output, Error>;
+  /** Define a query that bypasses schema validation. */
   <Input, Output, Error, Requirements>(
     validate: "unchecked",
     fn: (arg: Input) => Effect_type.Effect<Output, Error, Requirements>,
   ): EffectQueryFunction<Input, Output, Error>;
+  /** Define a query whose input is validated by an Effect.Schema. */
   <SchemaType extends EffectSchemaLike, Output, Error, Requirements>(
     validate: SchemaType,
     fn: (
       arg: SchemaOutput<SchemaType>,
     ) => Effect_type.Effect<Output, Error, Requirements>,
   ): EffectQueryFunction<SchemaInput<SchemaType>, Output, Error>;
+  /** Define a batched query - mirrors SvelteKit's `query.batch`. */
   batch: EffectQueryBatchFactory;
 }
 
+/**
+ * v4 overload set for the {@link Command} factory.
+ *
+ * @see https://ser.barekey.dev/content/remote-functions/command
+ */
 export interface EffectCommandFactory {
+  /** Define a void-input command. */
   <Output, Error, Requirements>(
     fn: () => Effect_type.Effect<Output, Error, Requirements>,
   ): EffectCommand<void, Output, Error>;
+  /** Define a command that bypasses schema validation. */
   <Input, Output, Error, Requirements>(
     validate: "unchecked",
     fn: (arg: Input) => Effect_type.Effect<Output, Error, Requirements>,
   ): EffectCommand<Input, Output, Error>;
+  /** Define a command whose input is validated by an Effect.Schema. */
   <SchemaType extends EffectSchemaLike, Output, Error, Requirements>(
     validate: SchemaType,
     fn: (
@@ -230,10 +362,17 @@ type RemotePrerenderInputsGenerator<Input> = (
   event: RequestEventService,
 ) => AsyncIterable<Input> | Iterable<Input>;
 
+/**
+ * v4 overload set for the {@link Form} factory.
+ *
+ * @see https://ser.barekey.dev/content/remote-functions/form
+ */
 export interface EffectFormFactory {
+  /** Define a form handler with no input data. */
   <Output, Error, Requirements>(
     fn: () => Effect_type.Effect<Output, Error, Requirements>,
   ): EffectForm<void, Output, Error>;
+  /** Define a form handler that bypasses schema validation. */
   <Input extends RemoteFormInput, Output, Error, Requirements>(
     validate: "unchecked",
     fn: (
@@ -243,6 +382,7 @@ export interface EffectFormFactory {
       },
     ) => Effect_type.Effect<Output, Error | FormError, Requirements>,
   ): EffectForm<Input, Output, Error>;
+  /** Define a form handler whose submitted data is validated by a schema. */
   <SchemaType extends EffectSchemaLike, Output, Error, Requirements>(
     validate: SchemaType,
     fn: (
@@ -258,6 +398,13 @@ export interface EffectFormFactory {
   ): EffectForm<SchemaInput<SchemaType> & RemoteFormInput, Output, Error>;
 }
 
+/**
+ * v4 overload set for the {@link Prerender} factory. Supports the same three
+ * validation flavours as the other factories plus a SvelteKit `options` bag
+ * with `inputs` / `dynamic` flags.
+ *
+ * @see https://ser.barekey.dev/content/remote-functions/prerender
+ */
 export interface EffectPrerenderFactory {
   <Output, Error, Requirements>(
     fn: () => Effect_type.Effect<Output, Error, Requirements>,
@@ -286,10 +433,40 @@ export interface EffectPrerenderFactory {
   ): EffectPrerenderFunction<SchemaInput<SchemaType>, Output, Error>;
 }
 
+/**
+ * v4 flavour of {@link import("$/v3/server.ts").Query} - define a read-only
+ * remote function returning an Effect.
+ *
+ * @see https://ser.barekey.dev/content/remote-functions/query
+ */
 export const Query: EffectQueryFactory = base_server.Query;
+/**
+ * v4 flavour of {@link import("$/v3/server.ts").Command} - define a
+ * write-oriented remote function returning an Effect.
+ *
+ * @see https://ser.barekey.dev/content/remote-functions/command
+ */
 export const Command: EffectCommandFactory = base_server.Command;
+/**
+ * v4 flavour of {@link import("$/v3/server.ts").Form} - define a remote form
+ * handler that maps submitted data into an Effect program.
+ *
+ * @see https://ser.barekey.dev/content/remote-functions/form
+ */
 export const Form: EffectFormFactory = base_server.Form;
+/**
+ * v4 flavour of {@link import("$/v3/server.ts").Prerender} - define a
+ * prerenderable remote function backed by an Effect program.
+ *
+ * @see https://ser.barekey.dev/content/remote-functions/prerender
+ */
 export const Prerender: EffectPrerenderFactory = base_server.Prerender;
+/**
+ * v4 Effect `Context.Tag` for the current SvelteKit `RequestEvent`. Shaped
+ * like an `Effect` so handlers can `yield* RequestEvent` directly.
+ *
+ * @see https://ser.barekey.dev/content/runtimes/server
+ */
 export const RequestEvent = make_context_key<
   RequestEventService,
   RequestEventService
@@ -298,10 +475,29 @@ export const RequestEvent = make_context_key<
 ) as
   & EffectContextKey<RequestEventService, RequestEventService>
   & Effect_type.Effect<RequestEventService, never, RequestEventService>;
+/**
+ * v4 server-side runtime builder. Equivalent to the v3 builder but typed
+ * against the v4 `Layer` operator signature.
+ *
+ * @see https://ser.barekey.dev/content/reference/server-runtime
+ */
 export const ServerRuntime: ServerRuntimeSeed = base_server.ServerRuntime;
+/**
+ * Build a devalue transport table from Effect schemas so remote payloads can
+ * round-trip custom data across the client/server boundary.
+ *
+ * @see https://ser.barekey.dev/content/reference/transport
+ */
 export const create_effect_transport:
   typeof base_server.create_effect_transport =
     base_server.create_effect_transport;
+/**
+ * Resolve the active v4 server runtime, lazily creating a default empty
+ * runtime when none has been registered.
+ *
+ * @internal Internal - do not use.
+ * @see https://ser.barekey.dev/content/reference/server-runtime
+ */
 export const get_server_runtime_or_throw: () => EffectManagedRuntime =
   base_server.get_server_runtime_or_throw;
 /**


### PR DESCRIPTION
## Summary
Addresses the documentation gaps flagged by JSR's score breakdown for `@barekey/svelte-effect-runtime` (issue #8, currently 52%).

- **Module docs in all entrypoints** — add `@module` JSDoc + usage example to every entrypoint that was missing one: `mod.ts`, `v3/mod.ts`, `v4/mod.ts`, `server.ts`, `v3/server.ts`, `v4/server.ts`. The other entrypoints (`preprocess.ts`, `vite.ts`, `effect.ts`, `language-server.ts`) already had them.
- **Examples in readme/module doc** — the new `@module` blocks include code examples, satisfying this criterion for the main entry.
- **Has docs for most symbols** — document the remaining ~70 undocumented exported symbols across the v3/v4 client + server surface and `internal/remote-shared.ts` (error types). Moves coverage from 23% to well above 80%.
- Genuinely internal plumbing (`get_server_runtime_or_throw`, `V4_RUNTIME_MODULE_ID`, `make_context_key`, etc.) is tagged `@internal Internal — do not use.` — JSR still counts those as documented.

`deno task check` passes.

## Out of scope (JSR web-UI settings, not source)
The remaining score items need to be set in the JSR package settings UI, not in code:
- **Has a description** — set a package description on https://jsr.io/@barekey/svelte-effect-runtime.
- **At least one / two runtimes are marked as compatible** — flag compatible runtimes (Deno, Node, Bun, browsers) in the same settings panel.

## Test plan
- [ ] CI runtime check passes
- [ ] After merge, JSR re-indexes the next published version and score jumps well past 52%

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `@module` docs with examples to all publish entrypoints and documents the v3/v4 client/server surface, raising the JSR score for `@barekey/svelte-effect-runtime` well above 80% (issue #8). Clarifies remote validation docs (`RemoteValidationError.status` defaults to 400 and can be overridden); internal plumbing is tagged `@internal`, no behavior changes, and remaining JSR items (package description, runtime compatibility flags) must be set in the JSR UI.

<sup>Written for commit 02fa1b12034bf389f3de84405724588d10b017e9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

