### PR TITLE
Release 1.4.0 sprint work

### DIFF
--- a/modules/svelte-effect-runtime-language-server/package.json
+++ b/modules/svelte-effect-runtime-language-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "svelte-effect-runtime-language-server",
   "private": true,
-  "version": "1.3.2",
+  "version": "1.4.0",
   "license": "BSD-3-Clause",
   "type": "commonjs",
   "main": "./dist/server.cjs",

--- a/modules/svelte-effect-runtime-language-server/patch-language-server.ts
+++ b/modules/svelte-effect-runtime-language-server/patch-language-server.ts
@@ -7,9 +7,10 @@ import MagicString from "magic-string";
 import { TraceMap } from "@jridgewell/trace-mapping";
 
 const require = createRequire(import.meta.url);
+const ts = require("typescript") as typeof import("typescript");
 const patch_marker = Symbol.for("svelte-effect-runtime.language-server.patch");
 const package_root = path.dirname(fileURLToPath(import.meta.url));
-const runtime_root = resolve_runtime_root(package_root);
+const runtime_import_root = resolve_runtime_import_root(package_root);
 const language_server_root = path.join(
   path.dirname(require.resolve("svelte-language-server/package.json")),
   "dist",
@@ -22,12 +23,12 @@ const { Document } = require(path.join(
   "documents",
   "Document.js",
 )) as { Document: any };
-const { SourceMapDocumentMapper } = require(path.join(
+const { FragmentMapper, SourceMapDocumentMapper } = require(path.join(
   language_server_root,
   "lib",
   "documents",
   "DocumentMapper.js",
-)) as { SourceMapDocumentMapper: any };
+)) as { FragmentMapper: any; SourceMapDocumentMapper: any };
 const { extractScriptTags } = require(path.join(
   language_server_root,
   "lib",
@@ -40,6 +41,13 @@ const { DocumentSnapshot } = require(path.join(
   "typescript",
   "DocumentSnapshot.js",
 )) as { DocumentSnapshot: any };
+const { CodeActionsProviderImpl } = require(path.join(
+  language_server_root,
+  "plugins",
+  "typescript",
+  "features",
+  "CodeActionsProvider.js",
+)) as { CodeActionsProviderImpl: any };
 const {
   TranspiledSvelteDocument,
   FallbackTranspiledSvelteDocument,
@@ -58,6 +66,17 @@ type Mapper = {
   getGeneratedPosition(position: any): any;
   isInGenerated(position: any): boolean;
 };
+
+type Relocation = {
+  originalStart: number;
+  originalEnd: number;
+  generatedStart: number;
+  generatedEnd: number;
+};
+
+function is_invalid_position(position: any) {
+  return position.line < 0 || position.character < 0;
+}
 
 export async function bootstrap_language_server() {
   if (DocumentSnapshot.fromDocument[patch_marker]) {
@@ -79,24 +98,41 @@ export async function bootstrap_language_server() {
     transformEffectMarkup: markupModule.transformEffectMarkup,
     transformEffectScript: transformModule.transformEffectScript,
   });
+  patch_typescript_code_actions();
 }
 
-function resolve_runtime_root(package_root: string) {
+function resolve_runtime_import_root(package_root: string) {
   const bundled_runtime_root = path.join(package_root, "runtime");
-  const workspace_runtime_root = path.resolve(
+  const workspace_source_root = path.resolve(
     package_root,
     "..",
     "svelte-effect-runtime",
-    "dist",
   );
+  const workspace_runtime_root = path.join(workspace_source_root, "dist");
 
-  return existsSync(workspace_runtime_root)
-    ? workspace_runtime_root
-    : bundled_runtime_root;
+  if (
+    typeof Deno !== "undefined" &&
+    existsSync(path.join(workspace_source_root, "preprocess.ts"))
+  ) {
+    return workspace_source_root;
+  }
+
+  if (existsSync(workspace_runtime_root)) {
+    return workspace_runtime_root;
+  }
+
+  return bundled_runtime_root;
 }
 
 function import_runtime_module(relativePath: string) {
-  return import(pathToFileURL(path.join(runtime_root, relativePath)).href);
+  const resolvedPath = path.join(
+    runtime_import_root,
+    runtime_import_root.endsWith(path.join("svelte-effect-runtime"))
+      ? relativePath.replace(/\.js$/, ".ts")
+      : relativePath,
+  );
+
+  return import(pathToFileURL(resolvedPath).href);
 }
 
 function patch_svelte_compiler_path(effectPreprocess: () => any) {
@@ -133,6 +169,8 @@ function patch_typescript_snapshot_path(
     };
     transformEffectScript: (code: string, options: { filename: string }) => {
       code: string;
+      map: Record<string, unknown>;
+      relocations?: Array<Relocation>;
     };
   },
 ) {
@@ -182,6 +220,48 @@ function patch_static_factory(
   target_class.create[patch_marker] = true;
 }
 
+function patch_typescript_code_actions() {
+  if (CodeActionsProviderImpl.prototype.applyQuickfix?.[patch_marker]) {
+    return;
+  }
+
+  const original_apply_quickfix = CodeActionsProviderImpl.prototype.applyQuickfix;
+
+  CodeActionsProviderImpl.prototype.applyQuickfix = async function applyQuickfix(
+    document: any,
+    range: { start: any; end: any },
+    context: any,
+    cancellationToken: any,
+  ) {
+    const { tsDoc } = await this.getLSAndTSDoc(document);
+    const generatedStart = tsDoc.getGeneratedPosition(range.start);
+    const generatedEnd = tsDoc.getGeneratedPosition(range.end);
+
+    if (
+      is_invalid_position(generatedStart) ||
+      is_invalid_position(generatedEnd)
+    ) {
+      return [];
+    }
+
+    const start = tsDoc.offsetAt(generatedStart);
+    const end = tsDoc.offsetAt(generatedEnd);
+
+    if (end < start) {
+      return [];
+    }
+
+    return original_apply_quickfix.call(
+      this,
+      document,
+      range,
+      context,
+      cancellationToken,
+    );
+  };
+  CodeActionsProviderImpl.prototype.applyQuickfix[patch_marker] = true;
+}
+
 function merge_preprocessors(existing: any, effectPreprocess: () => any) {
   if (contains_effect_preprocessor(existing)) {
     return existing;
@@ -190,7 +270,7 @@ function merge_preprocessors(existing: any, effectPreprocess: () => any) {
   const next = effectPreprocess();
 
   if (!existing) {
-    return [next];
+    return [next, create_typescript_fallback_preprocessor()];
   }
 
   if (Array.isArray(existing)) {
@@ -198,6 +278,43 @@ function merge_preprocessors(existing: any, effectPreprocess: () => any) {
   }
 
   return [next, existing];
+}
+
+function create_typescript_fallback_preprocessor() {
+  return {
+    name: "svelte-effect-runtime-language-server-ts-fallback",
+    script: ({ content, attributes, filename }: {
+      content: string;
+      attributes: Record<string, string | boolean>;
+      filename: string;
+    }) => {
+      if (attributes.lang !== "ts") {
+        return;
+      }
+
+      const { outputText, sourceMapText } = ts.transpileModule(content, {
+        fileName: filename,
+        compilerOptions: {
+          module: ts.ModuleKind.ESNext,
+          target: ts.ScriptTarget.ESNext,
+          sourceMap: true,
+          verbatimModuleSyntax: true,
+        },
+      });
+
+      return {
+        code: outputText,
+        map: sourceMapText,
+        attributes: {
+          ...Object.fromEntries(
+            Object.entries(attributes).filter(([key]) =>
+              key !== "lang" && key !== "type"
+            ),
+          ),
+        },
+      };
+    },
+  };
 }
 
 function contains_effect_preprocessor(preprocessors: any) {
@@ -218,6 +335,8 @@ function prepare_virtual_document(
     };
     transformEffectScript: (code: string, options: { filename: string }) => {
       code: string;
+      map: Record<string, unknown>;
+      relocations?: Array<Relocation>;
     };
   },
 ) {
@@ -234,6 +353,7 @@ function prepare_virtual_document(
   const scripts = extractScriptTags(currentCode);
 
   if (scripts?.script && has_own(scripts.script.attributes, "effect")) {
+    const preScriptTransformCode = currentCode;
     const magicString = new MagicString(currentCode);
     const transformedScript = transforms.transformEffectScript(
       scripts.script.content,
@@ -247,7 +367,7 @@ function prepare_virtual_document(
         transformedScript.code,
       );
       currentCode = magicString.toString();
-      scriptMapper = create_source_map_mapper(
+      const fullDocumentMapper = create_source_map_mapper(
         magicString.generateMap({
           hires: true,
           includeContent: true,
@@ -255,6 +375,23 @@ function prepare_virtual_document(
         }) as unknown as Record<string, unknown>,
         sourceUri,
       );
+      const transformedScripts = extractScriptTags(currentCode);
+      const transformedScriptTag = transformedScripts?.script;
+
+      if (transformedScriptTag) {
+        scriptMapper = create_script_content_mapper(
+          preScriptTransformCode,
+          currentCode,
+          scripts.script,
+          transformedScriptTag,
+          transformedScript.map,
+          transformedScript.relocations ?? [],
+          fullDocumentMapper,
+          sourceUri,
+        );
+      } else {
+        scriptMapper = fullDocumentMapper;
+      }
     }
   }
 
@@ -298,6 +435,278 @@ function create_source_map_mapper(
     } as any),
     sourceUri,
   ) as Mapper;
+}
+
+function create_script_content_mapper(
+  originalCode: string,
+  transformedCode: string,
+  originalTagInfo: any,
+  transformedTagInfo: any,
+  rawMap: Record<string, unknown>,
+  relocations: Array<Relocation>,
+  fullDocumentMapper: Mapper,
+  sourceUri: string,
+): Mapper {
+  const originalFragmentMapper = new FragmentMapper(
+    originalCode,
+    originalTagInfo,
+    sourceUri,
+  ) as Mapper;
+  const transformedFragmentMapper = new FragmentMapper(
+    transformedCode,
+    transformedTagInfo,
+    sourceUri,
+  ) as Mapper;
+  const sourceMapper = create_source_map_mapper(rawMap, sourceUri);
+  const relocationMapper = create_relocation_mapper(
+    originalTagInfo.content,
+    transformedTagInfo.content,
+    relocations,
+  );
+
+  return {
+    getOriginalPosition(generatedPosition: any) {
+      if (!transformedFragmentMapper.isInGenerated(generatedPosition)) {
+        return fullDocumentMapper.getOriginalPosition(generatedPosition);
+      }
+
+      const positionInTransformedFragment =
+        transformedFragmentMapper.getGeneratedPosition(generatedPosition);
+
+      if (is_invalid_position(positionInTransformedFragment)) {
+        return positionInTransformedFragment;
+      }
+
+      const relocatedOriginalPosition =
+        relocationMapper?.getOriginalPosition(positionInTransformedFragment);
+
+      if (
+        relocatedOriginalPosition &&
+        !is_invalid_position(relocatedOriginalPosition)
+      ) {
+        return originalFragmentMapper.getOriginalPosition(relocatedOriginalPosition);
+      }
+
+      const positionInOriginalFragment = sourceMapper.getOriginalPosition(
+        positionInTransformedFragment,
+      );
+
+      if (is_invalid_position(positionInOriginalFragment)) {
+        return positionInOriginalFragment;
+      }
+
+      return originalFragmentMapper.getOriginalPosition(positionInOriginalFragment);
+    },
+    getGeneratedPosition(originalPosition: any) {
+      if (!originalFragmentMapper.isInGenerated(originalPosition)) {
+        return fullDocumentMapper.getGeneratedPosition(originalPosition);
+      }
+
+      const positionInOriginalFragment =
+        originalFragmentMapper.getGeneratedPosition(originalPosition);
+
+      if (is_invalid_position(positionInOriginalFragment)) {
+        return positionInOriginalFragment;
+      }
+
+      const relocatedGeneratedPosition =
+        relocationMapper?.getGeneratedPosition(positionInOriginalFragment);
+
+      if (
+        relocatedGeneratedPosition &&
+        !is_invalid_position(relocatedGeneratedPosition)
+      ) {
+        return transformedFragmentMapper.getOriginalPosition(
+          relocatedGeneratedPosition,
+        );
+      }
+
+      const positionInTransformedFragment = sourceMapper.getGeneratedPosition(
+        positionInOriginalFragment,
+      );
+
+      if (is_invalid_position(positionInTransformedFragment)) {
+        return positionInTransformedFragment;
+      }
+
+      return transformedFragmentMapper.getOriginalPosition(
+        positionInTransformedFragment,
+      );
+    },
+    isInGenerated(originalPosition: any) {
+      const generatedPosition = this.getGeneratedPosition(originalPosition);
+      return !is_invalid_position(generatedPosition);
+    },
+  };
+}
+
+function create_relocation_mapper(
+  originalContent: string,
+  transformedContent: string,
+  relocations: Array<Relocation>,
+): Mapper | null {
+  if (relocations.length === 0) {
+    return null;
+  }
+
+  const originalOffsets = new OffsetTable(originalContent);
+  const transformedOffsets = new OffsetTable(transformedContent);
+
+  return {
+    getOriginalPosition(generatedPosition: any) {
+      const generatedOffset = transformedOffsets.offsetAt(generatedPosition);
+      const relocation = find_relocation(
+        relocations,
+        generatedOffset,
+        "generatedStart",
+        "generatedEnd",
+      );
+
+      if (!relocation) {
+        return { line: -1, character: -1 };
+      }
+
+      return originalOffsets.positionAt(
+        map_offset_between_ranges(
+          generatedOffset,
+          relocation.generatedStart,
+          relocation.generatedEnd,
+          relocation.originalStart,
+          relocation.originalEnd,
+        ),
+      );
+    },
+    getGeneratedPosition(originalPosition: any) {
+      const originalOffset = originalOffsets.offsetAt(originalPosition);
+      const relocation = find_relocation(
+        relocations,
+        originalOffset,
+        "originalStart",
+        "originalEnd",
+      );
+
+      if (!relocation) {
+        return { line: -1, character: -1 };
+      }
+
+      return transformedOffsets.positionAt(
+        map_offset_between_ranges(
+          originalOffset,
+          relocation.originalStart,
+          relocation.originalEnd,
+          relocation.generatedStart,
+          relocation.generatedEnd,
+        ),
+      );
+    },
+    isInGenerated(originalPosition: any) {
+      return !is_invalid_position(this.getGeneratedPosition(originalPosition));
+    },
+  };
+}
+
+function find_relocation(
+  relocations: Array<Relocation>,
+  offset: number,
+  startKey: "originalStart" | "generatedStart",
+  endKey: "originalEnd" | "generatedEnd",
+) {
+  let match: Relocation | null = null;
+
+  for (const relocation of relocations) {
+    if (offset < relocation[startKey] || offset > relocation[endKey]) {
+      continue;
+    }
+
+    if (
+      !match ||
+      relocation[endKey] - relocation[startKey] <
+        match[endKey] - match[startKey]
+    ) {
+      match = relocation;
+    }
+  }
+
+  return match;
+}
+
+function map_offset_between_ranges(
+  offset: number,
+  sourceStart: number,
+  sourceEnd: number,
+  targetStart: number,
+  targetEnd: number,
+) {
+  if (offset <= sourceStart) {
+    return targetStart;
+  }
+
+  if (offset >= sourceEnd) {
+    return targetEnd;
+  }
+
+  const sourceLength = Math.max(sourceEnd - sourceStart, 1);
+  const targetLength = Math.max(targetEnd - targetStart, 1);
+  const relativeOffset = Math.min(
+    Math.max(offset - sourceStart, 0),
+    sourceLength - 1,
+  );
+
+  return targetStart + Math.min(relativeOffset, targetLength - 1);
+}
+
+class OffsetTable {
+  private readonly lineStarts: number[];
+
+  constructor(text: string) {
+    this.lineStarts = [0];
+
+    for (let index = 0; index < text.length; index++) {
+      if (text.charCodeAt(index) === 10) {
+        this.lineStarts.push(index + 1);
+      }
+    }
+  }
+
+  offsetAt(position: { line: number; character: number }) {
+    if (position.line < 0 || position.line >= this.lineStarts.length) {
+      return -1;
+    }
+
+    return this.lineStarts[position.line] + position.character;
+  }
+
+  positionAt(offset: number) {
+    if (offset < 0) {
+      return { line: -1, character: -1 };
+    }
+
+    let low = 0;
+    let high = this.lineStarts.length - 1;
+
+    while (low <= high) {
+      const middle = Math.floor((low + high) / 2);
+      const lineStart = this.lineStarts[middle];
+      const nextLineStart = this.lineStarts[middle + 1] ?? Number.POSITIVE_INFINITY;
+
+      if (offset < lineStart) {
+        high = middle - 1;
+        continue;
+      }
+
+      if (offset >= nextLineStart) {
+        low = middle + 1;
+        continue;
+      }
+
+      return {
+        line: middle,
+        character: offset - lineStart,
+      };
+    }
+
+    return { line: -1, character: -1 };
+  }
 }
 
 function rebind_snapshot_to_original_document(
@@ -408,7 +817,7 @@ function map_offset_to_original(
     preprocessedDocument.positionAt(offset),
   );
 
-  if (originalPosition.line < 0 || originalPosition.character < 0) {
+  if (is_invalid_position(originalPosition)) {
     return offset;
   }
 
@@ -422,17 +831,23 @@ class SequentialDocumentMapper {
   ) {}
 
   getOriginalPosition(generatedPosition: any) {
-    return this.mappers.reduce(
-      (position, mapper) => mapper.getOriginalPosition(position),
-      generatedPosition,
-    );
+    return this.mappers.reduce((position, mapper) => {
+      if (is_invalid_position(position)) {
+        return position;
+      }
+
+      return mapper.getOriginalPosition(position);
+    }, generatedPosition);
   }
 
   getGeneratedPosition(originalPosition: any) {
-    return [...this.mappers].reverse().reduce(
-      (position, mapper) => mapper.getGeneratedPosition(position),
-      originalPosition,
-    );
+    return [...this.mappers].reverse().reduce((position, mapper) => {
+      if (is_invalid_position(position)) {
+        return position;
+      }
+
+      return mapper.getGeneratedPosition(position);
+    }, originalPosition);
   }
 
   isInGenerated(originalPosition: any) {
@@ -459,16 +874,21 @@ class SnapshotDocumentMapper {
   }
 
   getGeneratedPosition(originalPosition: any) {
-    return this.innerMapper.getGeneratedPosition(
-      this.preprocessMapper.getGeneratedPosition(originalPosition),
-    );
+    const preprocessedPosition =
+      this.preprocessMapper.getGeneratedPosition(originalPosition);
+
+    if (is_invalid_position(preprocessedPosition)) {
+      return preprocessedPosition;
+    }
+
+    return this.innerMapper.getGeneratedPosition(preprocessedPosition);
   }
 
   isInGenerated(originalPosition: any) {
     const preprocessedPosition =
       this.preprocessMapper.getGeneratedPosition(originalPosition);
 
-    if (preprocessedPosition.line < 0 || preprocessedPosition.character < 0) {
+    if (is_invalid_position(preprocessedPosition)) {
       return false;
     }
 

--- a/modules/svelte-effect-runtime-language-server/server.test.ts
+++ b/modules/svelte-effect-runtime-language-server/server.test.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import { createRequire } from "node:module";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import {
   assert,
   assertEquals as assert_equals,
@@ -10,16 +10,16 @@ import {
 import { bootstrap_language_server } from "./server.ts";
 
 const require = createRequire(import.meta.url);
+const module_dir = path.dirname(fileURLToPath(import.meta.url));
 const language_server_root = path.join(
   path.dirname(require.resolve("svelte-language-server/package.json")),
   "dist",
   "src",
 );
-const { Document } = require(path.join(
+const { DocumentManager, Document } = require(path.join(
   language_server_root,
   "lib",
   "documents",
-  "Document.js",
 ));
 const { DocumentSnapshot } = require(path.join(
   language_server_root,
@@ -32,6 +32,23 @@ const { SvelteDocument } = require(path.join(
   "plugins",
   "svelte",
   "SvelteDocument.js",
+));
+const { LSConfigManager } = require(path.join(
+  language_server_root,
+  "ls-config.js",
+));
+const { LSAndTSDocResolver } = require(path.join(
+  language_server_root,
+  "plugins",
+  "typescript",
+  "LSAndTSDocResolver.js",
+));
+const { HoverProviderImpl } = require(path.join(
+  language_server_root,
+  "plugins",
+  "typescript",
+  "features",
+  "HoverProvider.js",
 ));
 
 await bootstrap_language_server();
@@ -52,6 +69,180 @@ async function create_transform_options() {
     transformOnTemplateError: false,
     typingsNamespace: "svelteHTML",
   };
+}
+
+function to_posix_path(value: string) {
+  return value.split(path.sep).join("/");
+}
+
+async function create_checkout_fixture() {
+  const fixtures_root = path.join(module_dir, ".tmp");
+  await Deno.mkdir(fixtures_root, { recursive: true });
+  const fixture_dir = await Deno.makeTempDir({
+    dir: fixtures_root,
+    prefix: "checkout-hover-",
+  });
+  const routes_dir = path.join(fixture_dir, "src", "routes", "checkout");
+  await Deno.mkdir(routes_dir, { recursive: true });
+
+  await Deno.writeTextFile(
+    path.join(fixture_dir, "tsconfig.json"),
+    JSON.stringify({
+      compilerOptions: {
+        module: "ESNext",
+        moduleResolution: "bundler",
+        target: "ES2022",
+        strict: true,
+        allowJs: true,
+        checkJs: true,
+        skipLibCheck: true,
+        types: ["svelte"],
+      },
+      include: ["src/**/*.ts", "src/**/*.svelte"],
+    }, null, 2),
+  );
+  await Deno.writeTextFile(
+    path.join(fixture_dir, "package.json"),
+    JSON.stringify({
+      type: "module",
+    }, null, 2),
+  );
+  await Deno.writeTextFile(
+    path.join(fixture_dir, "svelte.config.js"),
+    `export default {
+  compilerOptions: {
+    runes: true,
+    experimental: {
+      async: true,
+    },
+  },
+};\n`,
+  );
+  await Deno.writeTextFile(
+    path.join(routes_dir, "errors.ts"),
+    `import { Data } from "effect";
+
+export class OutOfStock extends Data.TaggedError("OutOfStock")<{
+  readonly sku: string;
+}> {}
+
+export class PaymentDeclined extends Data.TaggedError("PaymentDeclined")<{
+  readonly reason: "fraud_suspected";
+}> {}
+`,
+  );
+  await Deno.writeTextFile(
+    path.join(routes_dir, "checkout.remote.ts"),
+    `import { Effect, Schema } from "effect";
+import { OutOfStock, PaymentDeclined } from "./errors";
+
+export const Order = Schema.Struct({
+  sku: Schema.String,
+  quantity: Schema.Number,
+});
+
+export type Order = typeof Order.Type;
+
+export const place_order = ({ sku, quantity }: Order) =>
+  Effect.gen(function* () {
+    if (sku === "mug-01") {
+      yield* Effect.fail(new OutOfStock({ sku }));
+    }
+
+    if (quantity >= 3) {
+      yield* Effect.fail(new PaymentDeclined({ reason: "fraud_suspected" }));
+    }
+
+    return {
+      sku,
+      quantity,
+      confirmation: "ord_demo",
+    };
+  });
+`,
+  );
+  await Deno.writeTextFile(
+    path.join(routes_dir, "+page.svelte"),
+    `<script lang="ts" effect>
+  import { Effect } from "effect";
+  import { place_order } from "./checkout.remote";
+
+  const request = { sku: "book-42", quantity: 3 } as const;
+
+  const result = yield* place_order(request).pipe(
+    Effect.catchTags({
+      OutOfStock: (error) =>
+        Effect.succeed({
+          kind: "error" as const,
+          message: error.sku,
+        }),
+      PaymentDeclined: (error) =>
+        Effect.succeed({
+          kind: "error" as const,
+          message: error.reason,
+        }),
+    }),
+    Effect.map((value) =>
+      "confirmation" in value
+        ? {
+            kind: "ok" as const,
+            message: value.confirmation,
+          }
+        : value
+    ),
+  );
+</script>
+
+{#if !result}
+  <p>Loading</p>
+{:else if result.kind === "ok"}
+  <p>{result.message}</p>
+{:else}
+  <p>{result.message}</p>
+{/if}
+`,
+  );
+
+  return fixture_dir;
+}
+
+async function get_hover_text(
+  fixture_dir: string,
+  needle: string,
+  offset_adjustment = 0,
+) {
+  const compiler = await load_compiler();
+  const file_path = path.join(fixture_dir, "src", "routes", "checkout", "+page.svelte");
+  const source = await Deno.readTextFile(file_path);
+  const doc_manager = new DocumentManager((textDocument: any) =>
+    new Document(textDocument.uri, textDocument.text)
+  );
+  const config_manager = new LSConfigManager();
+  const fixture_uri = pathToFileURL(fixture_dir).href.replace(/\/$/, "");
+  const resolver = new LSAndTSDocResolver(
+    doc_manager,
+    [fixture_uri],
+    config_manager,
+    {
+      watch: false,
+      tsSystem: require("typescript").sys,
+      tsconfigPath: path.join(fixture_dir, "tsconfig.json"),
+    },
+  );
+  const hover_provider = new HoverProviderImpl(resolver);
+  const document = doc_manager.openDocument({
+    uri: pathToFileURL(file_path).href,
+    text: source,
+  }, true);
+  document.openedByClient = true;
+  document._compiler = compiler;
+
+  const hover = await hover_provider.doHover(
+    document,
+    document.positionAt(source.indexOf(needle) + offset_adjustment),
+  );
+
+  return hover?.contents ?? null;
 }
 
 Deno.test("builds a mappable TS snapshot from Effect syntax", async () => {
@@ -98,6 +289,234 @@ Deno.test("builds a mappable TS snapshot from Effect syntax", async () => {
   assert(node.end >= pokemon_offset);
 });
 
+Deno.test("lowered yield declarations still map to generated script symbols", async () => {
+  const source = `<script lang="ts" effect>
+  import { TestRemote } from "./test.remote";
+
+  const test = yield* TestRemote({ name: "John", age: 20 });
+</script>`;
+
+  const document = Document.createForTest(
+    "file:///virtual/lowered-binding.svelte",
+    source,
+  );
+  const options = await create_transform_options();
+  const snapshot = DocumentSnapshot.fromDocument(document, options);
+  const test_offset = source.indexOf("test =") + 1;
+  const test_position = document.positionAt(test_offset);
+  const generated_test = snapshot.getGeneratedPosition(test_position);
+  const generated_test_offset = snapshot.offsetAt(generated_test);
+  const generated_test_window = snapshot.getFullText().slice(
+    Math.max(0, generated_test_offset - 60),
+    Math.min(snapshot.getFullText().length, generated_test_offset + 120),
+  );
+  const remote_offset = source.indexOf("TestRemote({");
+  const remote_position = document.positionAt(remote_offset);
+  const generated_remote = snapshot.getGeneratedPosition(remote_position);
+  const generated_remote_offset = snapshot.offsetAt(generated_remote);
+  const generated_remote_window = snapshot.getFullText().slice(
+    Math.max(0, generated_remote_offset - 60),
+    Math.min(snapshot.getFullText().length, generated_remote_offset + 120),
+  );
+
+  assert(generated_test.line >= 0);
+  assert_match(
+    generated_test_window,
+    /let test: __svelteEffectRuntimeYielded<ReturnType<typeof __svelteEffectRuntime_test_\d+>> \| undefined = \$state/,
+  );
+  assert(generated_remote.line >= 0);
+  assert_match(generated_remote_window, /TestRemote\(\{ name: "John", age: 20 \}\)/);
+});
+
+Deno.test("destructured bindings map each name to its own generated symbol", async () => {
+  const source = `<script lang="ts" effect>
+  import { Effect } from "effect";
+
+  const { first, second } = yield* Effect.succeed({ first: 1, second: 2 });
+</script>`;
+
+  const document = Document.createForTest(
+    "file:///virtual/destructured-bindings.svelte",
+    source,
+  );
+  const options = await create_transform_options();
+  const snapshot = DocumentSnapshot.fromDocument(document, options);
+  const second_offset = source.indexOf("second }") + 1;
+  const second_position = document.positionAt(second_offset);
+  const generated_second = snapshot.getGeneratedPosition(second_position);
+  const generated_second_offset = snapshot.offsetAt(generated_second);
+  const generated_second_window = snapshot.getFullText().slice(
+    Math.max(0, generated_second_offset - 60),
+    Math.min(snapshot.getFullText().length, generated_second_offset + 120),
+  );
+
+  assert(generated_second.line >= 0);
+  assert_match(generated_second_window, /let second = \$state<any>\(undefined\);/);
+  assert_not_match(generated_second_window, /let first = \$state<any>\(undefined\);/);
+});
+
+Deno.test("hover stays typed in script declarations and markup for checkout flows", async () => {
+  const fixture_dir = await create_checkout_fixture();
+
+  try {
+    const place_order_hover = await get_hover_text(
+      fixture_dir,
+      "place_order",
+    );
+    const request_hover = await get_hover_text(
+      fixture_dir,
+      "const request",
+      "const ".length,
+    );
+    const result_decl_hover = await get_hover_text(
+      fixture_dir,
+      "const result",
+      "const ".length,
+    );
+    const markup_hover = await get_hover_text(
+      fixture_dir,
+      "!result",
+      1,
+    );
+    const message_hover = await get_hover_text(
+      fixture_dir,
+      "result.message",
+      2,
+    );
+
+    assert(typeof place_order_hover === "string");
+    assert_match(
+      place_order_hover as string,
+      /OutOfStock \| PaymentDeclined/,
+    );
+    assert(typeof request_hover === "string");
+    assert_match(
+      request_hover as string,
+      /readonly sku: "book-42"/,
+    );
+    assert(typeof result_decl_hover === "string");
+    assert_match(
+      result_decl_hover as string,
+      /kind: "ok"/,
+    );
+    assert_match(
+      result_decl_hover as string,
+      /\| undefined/,
+    );
+    assert_not_match(result_decl_hover as string, /\bany\b/);
+    assert(typeof markup_hover === "string");
+    assert_match(
+      markup_hover as string,
+      /kind: "ok"/,
+    );
+    assert_match(
+      markup_hover as string,
+      /\| undefined/,
+    );
+    assert_not_match(markup_hover as string, /\bany\b/);
+    assert(typeof message_hover === "string");
+    assert_match(
+      message_hover as string,
+      /kind: "ok"/,
+    );
+    assert_not_match(message_hover as string, /\bundefined\b/);
+  } finally {
+    await Deno.remove(fixture_dir, { recursive: true }).catch(() => undefined);
+  }
+});
+
+Deno.test("snapshot mapping short-circuits invalid generated positions", async () => {
+  const source = `<script lang="ts" effect>
+  import { Effect } from "effect";
+  const count = yield* Effect.succeed(42);
+</script>
+
+<p>{count}</p>`;
+
+  const document = Document.createForTest(
+    "file:///virtual/effect-attribute.svelte",
+    source,
+  );
+  const options = await create_transform_options();
+  const snapshot = DocumentSnapshot.fromDocument(document, options);
+  const mapper = snapshot.getMapper() as {
+    preprocessMapper: {
+      mappers: Array<{
+        getGeneratedPosition(position: { line: number; character: number }): {
+          line: number;
+          character: number;
+        };
+        getOriginalPosition(position: { line: number; character: number }): {
+          line: number;
+          character: number;
+        };
+        isInGenerated(position: { line: number; character: number }): boolean;
+      }>;
+      getGeneratedPosition(position: { line: number; character: number }): {
+        line: number;
+        character: number;
+      };
+    };
+    innerMapper: {
+      getGeneratedPosition(position: { line: number; character: number }): {
+        line: number;
+        character: number;
+      };
+    };
+    getGeneratedPosition(position: { line: number; character: number }): {
+      line: number;
+      character: number;
+    };
+  };
+
+  mapper.preprocessMapper.mappers = [
+    {
+      getGeneratedPosition() {
+        throw new Error("Sequential mapper should stop after an invalid position.");
+      },
+      getOriginalPosition(position) {
+        return position;
+      },
+      isInGenerated() {
+        return true;
+      },
+    },
+    {
+      getGeneratedPosition() {
+        return { line: -1, character: -1 };
+      },
+      getOriginalPosition(position) {
+        return position;
+      },
+      isInGenerated() {
+        return false;
+      },
+    },
+  ];
+
+  assert_equals(
+    mapper.preprocessMapper.getGeneratedPosition({ line: 0, character: 0 }),
+    { line: -1, character: -1 },
+  );
+
+  mapper.preprocessMapper = {
+    ...mapper.preprocessMapper,
+    getGeneratedPosition() {
+      return { line: -1, character: -1 };
+    },
+  };
+  mapper.innerMapper = {
+    getGeneratedPosition() {
+      throw new Error("Snapshot mapper should not call the inner mapper.");
+    },
+  };
+
+  assert_equals(
+    mapper.getGeneratedPosition({ line: 0, character: 0 }),
+    { line: -1, character: -1 },
+  );
+});
+
 Deno.test("injects the runtime preprocessor into the Svelte compiler path", async () => {
   const compiler = await load_compiler();
   const source = `<script lang="ts" effect>
@@ -117,4 +536,33 @@ Deno.test("injects the runtime preprocessor into the Svelte compiler path", asyn
 
   assert_match(transpiled.getText(), /run_component_effect/);
   assert_not_match(transpiled.getText(), /<script[^>]*effect/);
+});
+
+Deno.test("injects a TS fallback preprocessor when config has no preprocess", async () => {
+  const compiler = await load_compiler();
+  const source = `<script lang="ts" effect>
+  import { Effect } from "effect";
+  const count: number = yield* Effect.succeed(42);
+</script>
+
+<p>{count}</p>`;
+
+  const document = Document.createForTest(
+    "file:///virtual/no-preprocess-config.svelte",
+    source,
+  );
+  document._compiler = compiler;
+  document.configPromise = Promise.resolve({
+    compilerOptions: {},
+  });
+
+  const transpiled = await new SvelteDocument(document).getTranspiled();
+  const transpiled_text = transpiled.getText();
+  const compiled = await new SvelteDocument(document).getCompiled();
+
+  assert_match(transpiled_text, /run_component_effect/);
+  assert_not_match(transpiled_text, /<script[^>]*effect/);
+  assert_not_match(transpiled_text, /<script[^>]*lang=/);
+  assert_not_match(transpiled_text, /const count: number/);
+  assert_equals(compiled.warnings, []);
 });

--- a/modules/svelte-effect-runtime-language-server/server.test.ts
+++ b/modules/svelte-effect-runtime-language-server/server.test.ts
@@ -349,10 +349,14 @@ Deno.test("destructured bindings map each name to its own generated symbol", asy
     Math.max(0, generated_second_offset - 60),
     Math.min(snapshot.getFullText().length, generated_second_offset + 120),
   );
+  const generated_second_token = snapshot.getFullText().slice(
+    generated_second_offset,
+    Math.min(snapshot.getFullText().length, generated_second_offset + 24),
+  );
 
   assert(generated_second.line >= 0);
   assert_match(generated_second_window, /let second = \$state<any>\(undefined\);/);
-  assert_not_match(generated_second_window, /let first = \$state<any>\(undefined\);/);
+  assert_match(generated_second_token, /^econd = \$state<any>\(/);
 });
 
 Deno.test("hover stays typed in script declarations and markup for checkout flows", async () => {

--- a/modules/svelte-effect-runtime-vscode-extension/package.json
+++ b/modules/svelte-effect-runtime-vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "svelte-effect-runtime-vscode",
   "displayName": "Svelte Effect Runtime",
   "description": "Cursor/VS Code integration for svelte-effect-runtime grammar-aware Svelte language support.",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "publisher": "barekey",
   "license": "BSD-3-Clause",
   "type": "module",

--- a/modules/svelte-effect-runtime/deno.json
+++ b/modules/svelte-effect-runtime/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@barekey/svelte-effect-runtime",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "license": "BSD-3-Clause",
   "exports": {
     ".": "./mod.ts",

--- a/modules/svelte-effect-runtime/internal/remote-client.ts
+++ b/modules/svelte-effect-runtime/internal/remote-client.ts
@@ -3,7 +3,6 @@ import { tick } from "svelte";
 import { create_remote_effect_from_promise } from "$/client.ts";
 import { create_async_effect } from "$internal/effect-compat.ts";
 import {
-  create_remote_domain_error,
   create_remote_http_error,
   create_remote_transport_error,
   create_remote_validation_error,
@@ -174,10 +173,9 @@ function decode_remote_error<ErrorType>(
 
     if (is_serialized_remote_failure_envelope(body)) {
       try {
-        return create_remote_domain_error<ErrorType>(
-          decode_payload<ErrorType>(body.encoded),
-          get_error_status(error),
-        );
+        return decode_payload<ErrorType>(
+          body.encoded,
+        ) as RemoteFailure<ErrorType>;
       } catch (cause) {
         return create_remote_transport_error(cause, body);
       }

--- a/modules/svelte-effect-runtime/internal/remote-shared.ts
+++ b/modules/svelte-effect-runtime/internal/remote-shared.ts
@@ -44,8 +44,13 @@ export interface FormError<SchemaType = unknown> {
 }
 
 /**
- * Remote failure carrying a domain error defined by the server-side
- * `Effect.fail(...)`. Preserves the original error value across the wire.
+ * Legacy wrapper around a typed server-side domain error value.
+ *
+ * @deprecated Tagged remote domain errors are no longer wrapped in
+ * `RemoteDomainError`. The user's own tagged error is now placed directly on
+ * the Effect error channel so `Effect.catchTag("YourTag", ...)` works without
+ * unwrapping. This interface is kept only for backwards compatibility with
+ * code that pattern-matched on `_tag === "RemoteDomainError"`.
  */
 export interface RemoteDomainError<ErrorType = unknown> {
   /** Discriminator identifying this variant of `RemoteFailure`. */
@@ -101,11 +106,15 @@ export interface RemoteTransportError {
 }
 
 /**
- * Union of every failure shape a remote function can produce on the client.
- * Use `_tag` to narrow before handling.
+ * Error channel produced by every remote Effect wrapper. A server-side
+ * `Effect.fail(MyTaggedError)` surfaces on the client as the raw `ErrorType`,
+ * so `Effect.catchTag("MyTag", ...)` narrows directly to your error. The
+ * framework-level failure variants (`RemoteValidationError`,
+ * `RemoteHttpError`, `RemoteTransportError`) are still included for transport
+ * and HTTP failures that the caller didn't model explicitly.
  */
 export type RemoteFailure<ErrorType = unknown> =
-  | RemoteDomainError<ErrorType>
+  | ErrorType
   | RemoteValidationError
   | RemoteHttpError
   | RemoteTransportError;
@@ -139,6 +148,11 @@ export function create_form_error<SchemaType = unknown>(
 
 /**
  * Build a {@link RemoteDomainError} around a typed server-side error value.
+ *
+ * @deprecated Remote tagged failures are no longer wrapped - the user's
+ * tagged error is forwarded directly on the Effect error channel. This helper
+ * is retained for backwards compatibility with downstream code that still
+ * constructs `RemoteDomainError` values explicitly.
  *
  * @internal Internal - do not use.
  */

--- a/modules/svelte-effect-runtime/internal/transform.ts
+++ b/modules/svelte-effect-runtime/internal/transform.ts
@@ -23,12 +23,43 @@ interface TransformEffectScriptOptions extends EffectPreprocessOptions {
 interface TransformEffectScriptResult {
   code: string;
   map: SourceMap;
+  relocations: Array<TransformRelocation>;
 }
 
 interface VariableStatementTransform {
   effectTexts: string[];
   hoistedText: string;
   loweredBindings: string[];
+  pendingRelocations: Array<PendingRelocation>;
+  usesPendingYieldHelper: boolean;
+}
+
+interface TransformRelocation {
+  originalStart: number;
+  originalEnd: number;
+  generatedStart: number;
+  generatedEnd: number;
+}
+
+interface PendingRelocation {
+  originalStart: number;
+  originalEnd: number;
+  generatedSnippet: string;
+  generatedInnerStart: number;
+  generatedInnerEnd: number;
+}
+
+interface StateDeclarationTransform {
+  code: string;
+  pendingRelocations: Array<PendingRelocation>;
+}
+
+interface LoweredDeclarationHelper {
+  declarationText: string;
+  stateTypeText: string;
+  assignmentExpression: string;
+  expressionRelocation: PendingRelocation;
+  tempName?: string;
 }
 
 const HOISTED_KINDS = new Set<ts.SyntaxKind>([
@@ -65,6 +96,7 @@ export function transformEffectScript(
 
   const effectStatements: Array<{ node: ts.Statement; text: string }> = [];
   const runtimeStatements: string[] = [];
+  const pendingRelocations: Array<PendingRelocation> = [];
   const magicString = new MagicString(content);
   const effectBoundBindings = new Set<string>();
 
@@ -92,6 +124,7 @@ export function transformEffectScript(
       }
 
       runtimeStatements.push(...transformed.effectTexts);
+      pendingRelocations.push(...transformed.pendingRelocations);
       for (const bindingName of transformed.loweredBindings) {
         effectBoundBindings.add(bindingName);
       }
@@ -116,6 +149,14 @@ export function transformEffectScript(
       node: statement,
       text: normalizeStatementText(sliceNode(content, statement)),
     });
+    pendingRelocations.push({
+      originalStart: statement.getStart(sourceFile),
+      originalEnd: statement.end,
+      generatedSnippet: normalizeStatementText(sliceNode(content, statement)),
+      generatedInnerStart: 0,
+      generatedInnerEnd: normalizeStatementText(sliceNode(content, statement))
+        .length,
+    });
   }
 
   for (const statement of [...effectStatements].reverse()) {
@@ -132,13 +173,16 @@ export function transformEffectScript(
     magicString.append(makeRuntimeBlock(allRuntimeStatements));
   }
 
+  const code = magicString.toString();
+
   return {
-    code: magicString.toString(),
+    code,
     map: magicString.generateMap({
       hires: true,
       includeContent: true,
       source: options.filename,
     }),
+    relocations: resolvePendingRelocations(pendingRelocations, code),
   };
 }
 
@@ -189,12 +233,15 @@ function transformVariableStatement(
       effectTexts: [],
       hoistedText: normalizeStatementText(sliceNode(content, statement)),
       loweredBindings: [],
+      pendingRelocations: [],
+      usesPendingYieldHelper: false,
     };
   }
 
   const effectTexts: string[] = [];
   const hoistedDeclarations: string[] = [];
   const loweredBindings: string[] = [];
+  const pendingRelocations: Array<PendingRelocation> = [];
 
   for (const declaration of statement.declarationList.declarations) {
     if (
@@ -210,10 +257,13 @@ function transformVariableStatement(
     }
 
     if (declaration.initializer && isRuneInitializer(declaration.initializer)) {
-      hoistedDeclarations.push(
+      const renderedDeclaration =
         `${getDeclarationKind(statement.declarationList.flags)} ${
           normalizeStatementText(sliceNode(content, declaration))
-        };`,
+        };`;
+      hoistedDeclarations.push(renderedDeclaration);
+      pendingRelocations.push(
+        ...make_declaration_relocations(declaration, renderedDeclaration, content),
       );
       continue;
     }
@@ -225,31 +275,72 @@ function transformVariableStatement(
         effectBoundBindings,
       )
     ) {
-      hoistedDeclarations.push(
+      const renderedDeclaration =
         `${getDeclarationKind(statement.declarationList.flags)} ${
           normalizeStatementText(sliceNode(content, declaration))
-        };`,
+        };`;
+      hoistedDeclarations.push(renderedDeclaration);
+      pendingRelocations.push(
+        ...make_declaration_relocations(declaration, renderedDeclaration, content),
       );
       continue;
     }
 
     const bindingNames = extractBindingNames(declaration.name);
+    const helper = create_lowered_declaration_helper(declaration, content);
+
+    if (helper) {
+      hoistedDeclarations.push(helper.declarationText);
+      pendingRelocations.push(helper.expressionRelocation);
+    }
+
+    if (helper?.tempName) {
+      hoistedDeclarations.push(
+        makeTypedStateBinding(helper.tempName, helper.stateTypeText),
+      );
+    }
 
     for (const bindingName of bindingNames) {
-      hoistedDeclarations.push(
-        makeStateDeclaration(bindingName, declaration, content),
+      const stateDeclaration = makeStateDeclaration(
+        bindingName,
+        declaration,
+        content,
+        helper?.tempName ? null : helper?.stateTypeText,
       );
+      hoistedDeclarations.push(stateDeclaration.code);
+      pendingRelocations.push(...stateDeclaration.pendingRelocations);
     }
     loweredBindings.push(...bindingNames);
 
     if (declaration.initializer) {
-      effectTexts.push(
-        makeEffectAssignment(
-          declaration.name,
-          declaration.initializer,
-          content,
-        ),
-      );
+      if (helper?.tempName) {
+        effectTexts.push(`${helper.tempName} = ${helper.assignmentExpression};`);
+        effectTexts.push(
+          makeEffectAssignment(
+            declaration.name,
+            helper.tempName,
+            content,
+          ),
+        );
+      } else {
+        const effectAssignment = helper
+          ? `${bindingNames[0]} = ${helper.assignmentExpression};`
+          : makeEffectAssignment(
+            declaration.name,
+            declaration.initializer,
+            content,
+          );
+        effectTexts.push(effectAssignment);
+        if (!helper) {
+          pendingRelocations.push(
+            makeEffectAssignmentRelocation(
+              declaration.initializer,
+              effectAssignment,
+              content,
+            ),
+          );
+        }
+      }
     }
   }
 
@@ -257,6 +348,8 @@ function transformVariableStatement(
     effectTexts,
     hoistedText: hoistedDeclarations.join("\n"),
     loweredBindings,
+    pendingRelocations,
+    usesPendingYieldHelper: false,
   };
 }
 
@@ -420,30 +513,74 @@ function makeStateDeclaration(
   name: string,
   declaration: ts.VariableDeclaration,
   content: string,
-): string {
+  inferredTypeText?: string | null,
+): StateDeclarationTransform {
+  let stateTypeText: string | null = null;
+
   if (ts.isIdentifier(declaration.name) && declaration.type) {
-    const typeText = normalizeStatementText(
+    stateTypeText = normalizeStatementText(
       sliceNode(content, declaration.type),
     );
-    return `let ${name} = $state<${typeText} | undefined>(undefined);`;
+  } else if (inferredTypeText) {
+    stateTypeText = inferredTypeText;
   }
 
-  return `let ${name} = $state<any>(undefined);`;
+  const code = stateTypeText
+    ? makeTypedStateBinding(name, stateTypeText)
+    : `let ${name} = $state<any>(undefined);`;
+
+  const nameStart = code.indexOf(name);
+  const pendingRelocations: Array<PendingRelocation> = [{
+    originalStart: find_binding_name_start(declaration.name, name),
+    originalEnd: find_binding_name_end(declaration.name, name),
+    generatedSnippet: "",
+    generatedInnerStart: nameStart,
+    generatedInnerEnd: nameStart + name.length,
+  }];
+
+  pendingRelocations[0] = {
+    ...pendingRelocations[0],
+    generatedSnippet: code,
+  };
+
+  return {
+    code,
+    pendingRelocations,
+  };
 }
 
 function makeEffectAssignment(
   name: ts.BindingName,
-  initializer: ts.Expression,
+  initializer: ts.Expression | string,
   content: string,
 ): string {
   const target = normalizeStatementText(sliceNode(content, name));
-  const expression = normalizeStatementText(sliceNode(content, initializer));
+  const expression = typeof initializer === "string"
+    ? initializer
+    : normalizeStatementText(sliceNode(content, initializer));
 
   if (ts.isIdentifier(name)) {
     return `${target} = ${expression};`;
   }
 
   return `(${target} = ${expression});`;
+}
+
+function makeEffectAssignmentRelocation(
+  initializer: ts.Expression,
+  effectAssignment: string,
+  content: string,
+): PendingRelocation {
+  const expression = normalizeStatementText(sliceNode(content, initializer));
+  const generatedInnerStart = effectAssignment.lastIndexOf(expression);
+
+  return {
+    originalStart: initializer.getStart(),
+    originalEnd: initializer.end,
+    generatedSnippet: effectAssignment,
+    generatedInnerStart,
+    generatedInnerEnd: generatedInnerStart + expression.length,
+  };
 }
 
 function extractBindingNames(name: ts.BindingName): string[] {
@@ -499,6 +636,20 @@ function containsYieldStar(node: ts.Node): boolean {
   );
 }
 
+function getYieldOperand(node: ts.Node | undefined): ts.Expression | null {
+  if (
+    node &&
+    ts.isBinaryExpression(node) &&
+    node.operatorToken.kind === ts.SyntaxKind.AsteriskToken &&
+    ts.isIdentifier(node.left) &&
+    node.left.text === "yield"
+  ) {
+    return node.right;
+  }
+
+  return null;
+}
+
 function containsTopLevelAwait(node: ts.Node): boolean {
   if (ts.isAwaitExpression(node)) {
     return true;
@@ -532,17 +683,143 @@ function indentBlock(text: string, indent: string): string {
   ).join("\n");
 }
 
-function makeInjectedImports(options: TransformEffectScriptOptions): string {
+function makeInjectedImports(
+  options: TransformEffectScriptOptions,
+): string {
   const runtimeModuleId = options.runtimeModuleId ?? DEFAULT_RUNTIME_MODULE_ID;
   const effectModuleId = options.effectModuleId ?? DEFAULT_EFFECT_MODULE_ID;
   const svelteModuleId = options.svelteModuleId ?? DEFAULT_SVELTE_MODULE_ID;
 
-  return [
+  const lines = [
     `import { onMount as __svelteEffectRuntimeOnMount } from "${svelteModuleId}";`,
     `import { Effect as __svelteEffectRuntimeEffect } from "${effectModuleId}";`,
     `import { get_effect_runtime_or_throw as __svelteEffectRuntimeGetRuntime, run_component_effect as __svelteEffectRuntimeRunComponentEffect } from "${runtimeModuleId}";`,
-    "",
-  ].join("\n");
+    `type __svelteEffectRuntimeYielded<T> = T extends __svelteEffectRuntimeEffect.Effect<infer A, any, any> ? A : T;`,
+  ];
+
+  lines.push("");
+  return lines.join("\n");
+}
+
+function makeTypedStateBinding(name: string, stateTypeText: string): string {
+  return `let ${name}: ${stateTypeText} | undefined = $state(undefined as ${stateTypeText} | undefined);`;
+}
+
+function create_lowered_declaration_helper(
+  declaration: ts.VariableDeclaration,
+  content: string,
+): LoweredDeclarationHelper | null {
+  if (declaration.type || !declaration.initializer) {
+    return null;
+  }
+
+  const bindingNames = extractBindingNames(declaration.name);
+  const suffix = declaration.getStart();
+  const baseName = bindingNames[0] ?? "binding";
+  const helperName = `__svelteEffectRuntime_${baseName}_${suffix}`;
+  const expressionNode = getYieldOperand(declaration.initializer) ??
+    declaration.initializer;
+  const expressionText = normalizeStatementText(sliceNode(content, expressionNode));
+  const declarationText = `const ${helperName} = () => ${expressionText};`;
+  const yieldedExpression = getYieldOperand(declaration.initializer);
+  const stateTypeText = yieldedExpression
+    ? `__svelteEffectRuntimeYielded<ReturnType<typeof ${helperName}>>`
+    : `ReturnType<typeof ${helperName}>`;
+  const assignmentExpression = yieldedExpression
+    ? `yield* ${helperName}()`
+    : `${helperName}()`;
+
+  return {
+    declarationText,
+    stateTypeText,
+    assignmentExpression,
+    tempName: ts.isIdentifier(declaration.name)
+      ? undefined
+      : `__svelteEffectRuntimeTemp_${suffix}`,
+    expressionRelocation: {
+      originalStart: expressionNode.getStart(),
+      originalEnd: expressionNode.end,
+      generatedSnippet: declarationText,
+      generatedInnerStart: declarationText.lastIndexOf(expressionText),
+      generatedInnerEnd: declarationText.lastIndexOf(expressionText) +
+        expressionText.length,
+    },
+  };
+}
+
+function make_declaration_relocations(
+  declaration: ts.VariableDeclaration,
+  renderedDeclaration: string,
+  content: string,
+): Array<PendingRelocation> {
+  const relocations: Array<PendingRelocation> = [];
+
+  if (ts.isIdentifier(declaration.name)) {
+    const nameStart = renderedDeclaration.indexOf(declaration.name.text);
+    relocations.push({
+      originalStart: declaration.name.getStart(),
+      originalEnd: declaration.name.end,
+      generatedSnippet: renderedDeclaration,
+      generatedInnerStart: nameStart,
+      generatedInnerEnd: nameStart + declaration.name.text.length,
+    });
+  }
+
+  if (declaration.initializer) {
+    const initializerText = normalizeStatementText(
+      sliceNode(content, declaration.initializer),
+    );
+    const initializerStart = renderedDeclaration.lastIndexOf(initializerText);
+    if (initializerStart >= 0) {
+      relocations.push({
+        originalStart: declaration.initializer.getStart(),
+        originalEnd: declaration.initializer.end,
+        generatedSnippet: renderedDeclaration,
+        generatedInnerStart: initializerStart,
+        generatedInnerEnd: initializerStart + initializerText.length,
+      });
+    }
+  }
+
+  return relocations;
+}
+
+function find_binding_name_start(name: ts.BindingName, bindingName: string): number {
+  if (ts.isIdentifier(name)) {
+    return name.text === bindingName ? name.getStart() : -1;
+  }
+
+  for (const element of name.elements) {
+    if (ts.isOmittedExpression(element)) {
+      continue;
+    }
+
+    const start = find_binding_name_start(element.name, bindingName);
+    if (start !== -1) {
+      return start;
+    }
+  }
+
+  return -1;
+}
+
+function find_binding_name_end(name: ts.BindingName, bindingName: string): number {
+  if (ts.isIdentifier(name)) {
+    return name.text === bindingName ? name.end : -1;
+  }
+
+  for (const element of name.elements) {
+    if (ts.isOmittedExpression(element)) {
+      continue;
+    }
+
+    const end = find_binding_name_end(element.name, bindingName);
+    if (end !== -1) {
+      return end;
+    }
+  }
+
+  return -1;
 }
 
 function makeRuntimeBlock(statements: string[]): string {
@@ -566,4 +843,30 @@ function makeRuntimeBlock(statements: string[]): string {
     "});",
     "",
   ].join("\n");
+}
+
+function resolvePendingRelocations(
+  pendingRelocations: Array<PendingRelocation>,
+  code: string,
+): Array<TransformRelocation> {
+  const relocations: Array<TransformRelocation> = [];
+  let searchStart = 0;
+
+  for (const relocation of pendingRelocations) {
+    const generatedStart = code.indexOf(relocation.generatedSnippet, searchStart);
+
+    if (generatedStart === -1) {
+      continue;
+    }
+
+    searchStart = generatedStart + relocation.generatedSnippet.length;
+    relocations.push({
+      originalStart: relocation.originalStart,
+      originalEnd: relocation.originalEnd,
+      generatedStart: generatedStart + relocation.generatedInnerStart,
+      generatedEnd: generatedStart + relocation.generatedInnerEnd,
+    });
+  }
+
+  return relocations;
 }

--- a/modules/svelte-effect-runtime/package.json
+++ b/modules/svelte-effect-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte-effect-runtime",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "description": "Client-side Effect runtime support for Svelte <script> blocks.",
   "license": "BSD-3-Clause",
   "type": "module",

--- a/modules/svelte-effect-runtime/preprocess.ts
+++ b/modules/svelte-effect-runtime/preprocess.ts
@@ -31,3 +31,9 @@ export function effect_preprocess(
 ): PreprocessorGroup {
   return create_effect_preprocess(options);
 }
+
+/**
+ * Backwards-compatible camelCase alias retained for older test fixtures and
+ * downstream code that imported the preprocessor before the snake_case rename.
+ */
+export const effectPreprocess = effect_preprocess;

--- a/modules/svelte-effect-runtime/test/remote.test.ts
+++ b/modules/svelte-effect-runtime/test/remote.test.ts
@@ -114,8 +114,7 @@ Deno.test("query adapter decodes domain failures into the Effect error channel",
     unknown,
     {
       _tag: string;
-      cause: unknown;
-      status: number;
+      id: string;
     },
     never
   >;
@@ -129,14 +128,7 @@ Deno.test("query adapter decodes domain failures into the Effect error channel",
 
   const failure = Cause.failureOption(exit.cause);
   assertEquals(Option.isSome(failure), true);
-  assertEquals(
-    Option.getOrUndefined(failure),
-    {
-      _tag: "RemoteDomainError",
-      cause: payload,
-      status: 409,
-    },
-  );
+  assertEquals(Option.getOrUndefined(failure), payload);
 
   assertEquals(to_native(get_post) instanceof Function, true);
 });
@@ -163,22 +155,21 @@ Deno.test("query adapter supports catchTag over transported remote domain errors
   const get_provider = query_factory("hash/get_provider") as () =>
     Effect.Effect<
       unknown,
-      RemoteDomainError<{
-        _tag: "ProviderBusyError";
-        provider: string;
-        retryAfterMs: number;
-      }>,
+      {
+        readonly _tag: "ProviderBusyError";
+        readonly provider: string;
+        readonly retryAfterMs: number;
+      },
       never
     >;
 
   const result = await Effect.runPromise(
     get_provider().pipe(
-      Effect.catchTag("RemoteDomainError", (error) =>
+      Effect.catchTag("ProviderBusyError", (error) =>
         Effect.succeed({
-          matchedTag: error.cause._tag,
-          provider: error.cause.provider,
-          retryAfterMs: error.cause.retryAfterMs,
-          status: error.status,
+          matchedTag: error._tag,
+          provider: error.provider,
+          retryAfterMs: error.retryAfterMs,
         })),
     ),
   );
@@ -187,7 +178,6 @@ Deno.test("query adapter supports catchTag over transported remote domain errors
     matchedTag: "ProviderBusyError",
     provider: "github",
     retryAfterMs: 1500,
-    status: 503,
   });
 });
 
@@ -223,14 +213,7 @@ Deno.test("to_effect preserves typed remote failures for native remote calls", a
 
   const failure = Cause.failureOption(exit.cause);
   assertEquals(Option.isSome(failure), true);
-  assertEquals(
-    Option.getOrUndefined(failure),
-    {
-      _tag: "RemoteDomainError",
-      cause: payload,
-      status: 409,
-    },
-  );
+  assertEquals(Option.getOrUndefined(failure), payload);
 });
 
 Deno.test("command adapter proxies pending and preserves native access", () => {

--- a/modules/svelte-effect-runtime/test/transform.test.ts
+++ b/modules/svelte-effect-runtime/test/transform.test.ts
@@ -41,14 +41,24 @@ Deno.test("rewrites effect-enabled scripts into a mount-time Effect program", as
   );
   assertStringIncludes(
     result.code,
-    `import { getEffectRuntimeOrThrow as __svelteEffectRuntimeGetRuntime`,
+    `import { get_effect_runtime_or_throw as __svelteEffectRuntimeGetRuntime`,
   );
   assertStringIncludes(
     result.code,
     `const __svelteEffectRuntimeProgram = __svelteEffectRuntimeEffect.gen(function* () {`,
   );
-  assertStringIncludes(result.code, `count = yield* Effect.succeed(42);`);
-  assertMatch(result.code, /let count = \$state<any>\(undefined\);/);
+  assertMatch(
+    result.code,
+    /const __svelteEffectRuntime_count_\d+ = \(\) => Effect\.succeed\(42\);/,
+  );
+  assertMatch(
+    result.code,
+    /let count: __svelteEffectRuntimeYielded<ReturnType<typeof __svelteEffectRuntime_count_\d+>> \| undefined = \$state\(undefined as __svelteEffectRuntimeYielded<ReturnType<typeof __svelteEffectRuntime_count_\d+>> \| undefined\);/,
+  );
+  assertMatch(
+    result.code,
+    /count = yield\* __svelteEffectRuntime_count_\d+\(\);/,
+  );
 });
 
 Deno.test("keeps declarations hoisted while moving executable statements", async () => {
@@ -86,7 +96,7 @@ Deno.test("preserves explicit type annotations when lowering yield declarations"
 
   assertStringIncludes(
     result.code,
-    `let count = $state<number | undefined>(undefined);`,
+    `let count: number | undefined = $state(undefined as number | undefined);`,
   );
 });
 
@@ -102,9 +112,21 @@ Deno.test("supports destructuring declarations that depend on yield*", async () 
   });
 
   assertStringIncludes(result.code, `let value = $state<any>(undefined);`);
-  assertStringIncludes(
+  assertMatch(
     result.code,
-    `({ value } = yield* Effect.succeed({ value: 1 }));`,
+    /const __svelteEffectRuntime_value_\d+ = \(\) => Effect\.succeed\(\{ value: 1 \}\);/,
+  );
+  assertMatch(
+    result.code,
+    /let __svelteEffectRuntimeTemp_\d+: __svelteEffectRuntimeYielded<ReturnType<typeof __svelteEffectRuntime_value_\d+>> \| undefined = \$state\(undefined as __svelteEffectRuntimeYielded<ReturnType<typeof __svelteEffectRuntime_value_\d+>> \| undefined\);/,
+  );
+  assertMatch(
+    result.code,
+    /__svelteEffectRuntimeTemp_\d+ = yield\* __svelteEffectRuntime_value_\d+\(\);/,
+  );
+  assertMatch(
+    result.code,
+    /\(\{ value \} = __svelteEffectRuntimeTemp_\d+\);/,
   );
 });
 
@@ -122,11 +144,17 @@ Deno.test("later declarations can depend on yielded values", async () => {
     filename: "Derived.svelte",
   });
 
-  assertStringIncludes(result.code, `let count = $state<any>(undefined);`);
-  assertStringIncludes(result.code, `let doubled = $state<any>(undefined);`);
   assertMatch(
     result.code,
-    /count = yield\* Effect\.succeed\(2\);\s+doubled = count \* 2;/s,
+    /let count: __svelteEffectRuntimeYielded<ReturnType<typeof __svelteEffectRuntime_count_\d+>> \| undefined = \$state\(undefined as __svelteEffectRuntimeYielded<ReturnType<typeof __svelteEffectRuntime_count_\d+>> \| undefined\);/,
+  );
+  assertMatch(
+    result.code,
+    /let doubled: ReturnType<typeof __svelteEffectRuntime_doubled_\d+> \| undefined = \$state\(undefined as ReturnType<typeof __svelteEffectRuntime_doubled_\d+> \| undefined\);/,
+  );
+  assertMatch(
+    result.code,
+    /count = yield\* __svelteEffectRuntime_count_\d+\(\);\s+doubled = __svelteEffectRuntime_doubled_\d+\(\);/s,
   );
 });
 

--- a/modules/svelte-effect-runtime/tests/shared/register-remote-behaviors.ts
+++ b/modules/svelte-effect-runtime/tests/shared/register-remote-behaviors.ts
@@ -15,7 +15,6 @@ import {
 import {
   EFFECT_REMOTE_ERROR_MARKER,
   type FormIssue,
-  type RemoteDomainError,
 } from "$internal/remote-shared.ts";
 import { installDom } from "$tests/shared/support.ts";
 import type { VersionHarness } from "$tests/shared/versions.ts";
@@ -129,8 +128,7 @@ export function register_remote_behaviors(harness: VersionHarness): void {
       unknown,
       {
         _tag: string;
-        cause: unknown;
-        status: number;
+        id: string;
       },
       never
     >;
@@ -144,14 +142,7 @@ export function register_remote_behaviors(harness: VersionHarness): void {
 
     const failure = Cause.failureOption(exit.cause);
     assertEquals(Option.isSome(failure), true);
-    assertEquals(
-      Option.getOrUndefined(failure),
-      {
-        _tag: "RemoteDomainError",
-        cause: payload,
-        status: 409,
-      },
-    );
+    assertEquals(Option.getOrUndefined(failure), payload);
 
     assertEquals(to_native(get_post) instanceof Function, true);
   });
@@ -178,22 +169,21 @@ export function register_remote_behaviors(harness: VersionHarness): void {
     const get_provider = query_factory("hash/get_provider") as () =>
       Effect.Effect<
         unknown,
-        RemoteDomainError<{
-          _tag: "ProviderBusyError";
-          provider: string;
-          retryAfterMs: number;
-        }>,
+        {
+          readonly _tag: "ProviderBusyError";
+          readonly provider: string;
+          readonly retryAfterMs: number;
+        },
         never
       >;
 
     const result = await Effect.runPromise(
       get_provider().pipe(
-        Effect.catchTag("RemoteDomainError", (error) =>
+        Effect.catchTag("ProviderBusyError", (error) =>
           Effect.succeed({
-            matchedTag: error.cause._tag,
-            provider: error.cause.provider,
-            retryAfterMs: error.cause.retryAfterMs,
-            status: error.status,
+            matchedTag: error._tag,
+            provider: error.provider,
+            retryAfterMs: error.retryAfterMs,
           })),
       ),
     );
@@ -202,7 +192,6 @@ export function register_remote_behaviors(harness: VersionHarness): void {
       matchedTag: "ProviderBusyError",
       provider: "github",
       retryAfterMs: 1500,
-      status: 503,
     });
   });
 
@@ -240,14 +229,7 @@ export function register_remote_behaviors(harness: VersionHarness): void {
 
     const failure = Cause.failureOption(exit.cause);
     assertEquals(Option.isSome(failure), true);
-    assertEquals(
-      Option.getOrUndefined(failure),
-      {
-        _tag: "RemoteDomainError",
-        cause: payload,
-        status: 409,
-      },
-    );
+    assertEquals(Option.getOrUndefined(failure), payload);
   });
 
   Deno.test(`[${label}] command adapters proxy pending state and preserve native access`, () => {

--- a/modules/svelte-effect-runtime/tests/shared/register-transform-behaviors.ts
+++ b/modules/svelte-effect-runtime/tests/shared/register-transform-behaviors.ts
@@ -54,8 +54,18 @@ export function register_transform_behaviors(harness: VersionHarness): void {
         result.code,
         `const __svelteEffectRuntimeProgram = __svelteEffectRuntimeEffect.gen(function* () {`,
       );
-      assertStringIncludes(result.code, `count = yield* Effect.succeed(42);`);
-      assertMatch(result.code, /let count = \$state<any>\(undefined\);/);
+      assertMatch(
+        result.code,
+        /const __svelteEffectRuntime_count_\d+ = \(\) => Effect\.succeed\(42\);/,
+      );
+      assertMatch(
+        result.code,
+        /let count: __svelteEffectRuntimeYielded<ReturnType<typeof __svelteEffectRuntime_count_\d+>> \| undefined = \$state\(undefined as __svelteEffectRuntimeYielded<ReturnType<typeof __svelteEffectRuntime_count_\d+>> \| undefined\);/,
+      );
+      assertMatch(
+        result.code,
+        /count = yield\* __svelteEffectRuntime_count_\d+\(\);/,
+      );
     },
   );
 
@@ -101,7 +111,7 @@ export function register_transform_behaviors(harness: VersionHarness): void {
 
       assertStringIncludes(
         result.code,
-        `let count = $state<number | undefined>(undefined);`,
+        `let count: number | undefined = $state(undefined as number | undefined);`,
       );
     },
   );
@@ -120,9 +130,21 @@ export function register_transform_behaviors(harness: VersionHarness): void {
       });
 
       assertStringIncludes(result.code, `let value = $state<any>(undefined);`);
-      assertStringIncludes(
+      assertMatch(
         result.code,
-        `({ value } = yield* Effect.succeed({ value: 1 }));`,
+        /const __svelteEffectRuntime_value_\d+ = \(\) => Effect\.succeed\(\{ value: 1 \}\);/,
+      );
+      assertMatch(
+        result.code,
+        /let __svelteEffectRuntimeTemp_\d+: __svelteEffectRuntimeYielded<ReturnType<typeof __svelteEffectRuntime_value_\d+>> \| undefined = \$state\(undefined as __svelteEffectRuntimeYielded<ReturnType<typeof __svelteEffectRuntime_value_\d+>> \| undefined\);/,
+      );
+      assertMatch(
+        result.code,
+        /__svelteEffectRuntimeTemp_\d+ = yield\* __svelteEffectRuntime_value_\d+\(\);/,
+      );
+      assertMatch(
+        result.code,
+        /\(\{ value \} = __svelteEffectRuntimeTemp_\d+\);/,
       );
     },
   );
@@ -143,14 +165,17 @@ export function register_transform_behaviors(harness: VersionHarness): void {
         filename: "Derived.svelte",
       });
 
-      assertStringIncludes(result.code, `let count = $state<any>(undefined);`);
-      assertStringIncludes(
+      assertMatch(
         result.code,
-        `let doubled = $state<any>(undefined);`,
+        /let count: __svelteEffectRuntimeYielded<ReturnType<typeof __svelteEffectRuntime_count_\d+>> \| undefined = \$state\(undefined as __svelteEffectRuntimeYielded<ReturnType<typeof __svelteEffectRuntime_count_\d+>> \| undefined\);/,
       );
       assertMatch(
         result.code,
-        /count = yield\* Effect\.succeed\(2\);\s+doubled = count \* 2;/s,
+        /let doubled: ReturnType<typeof __svelteEffectRuntime_doubled_\d+> \| undefined = \$state\(undefined as ReturnType<typeof __svelteEffectRuntime_doubled_\d+> \| undefined\);/,
+      );
+      assertMatch(
+        result.code,
+        /count = yield\* __svelteEffectRuntime_count_\d+\(\);\s+doubled = __svelteEffectRuntime_doubled_\d+\(\);/s,
       );
     },
   );

--- a/modules/svelte-effect-runtime/v3/client.ts
+++ b/modules/svelte-effect-runtime/v3/client.ts
@@ -1,7 +1,6 @@
 import { Cause, Effect, Exit, Layer, ManagedRuntime } from "effect";
 import { getContext, hasContext, onDestroy, setContext } from "svelte";
 import {
-  create_remote_domain_error,
   create_remote_http_error,
   create_remote_transport_error,
   create_remote_validation_error,
@@ -386,10 +385,9 @@ function decode_remote_error<ErrorType>(
 
     if (is_serialized_remote_failure_envelope(body) && decode_payload) {
       try {
-        return create_remote_domain_error<ErrorType>(
-          decode_payload<ErrorType>(body.encoded),
-          get_error_status(error),
-        );
+        return decode_payload<ErrorType>(
+          body.encoded,
+        ) as RemoteFailure<ErrorType>;
       } catch (cause) {
         return create_remote_transport_error(cause, body);
       }

--- a/modules/svelte-effect-runtime/v3/server.ts
+++ b/modules/svelte-effect-runtime/v3/server.ts
@@ -523,7 +523,57 @@ function log_remote_server_step(
     return;
   }
 
-  console.log("[svelte-effect-runtime][server]", step, details ?? {});
+  console.log(
+    "[svelte-effect-runtime][server]",
+    step,
+    details ? summarize_log_details(details) : {},
+  );
+}
+
+/**
+ * Tagged Effect failures are often `Data.TaggedError` subclasses (i.e. real
+ * `Error` objects). `console.log`-ing them dumps the full JS stack — which
+ * looks like a server crash, even though the failure is a modelled,
+ * caller-handleable error. Render such values as their tag + enumerable data
+ * instead so the dev log stays readable.
+ */
+function summarize_log_details(
+  details: Record<string, unknown>,
+): Record<string, unknown> {
+  const summarized: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(details)) {
+    summarized[key] = summarize_log_value(value);
+  }
+
+  return summarized;
+}
+
+function summarize_log_value(value: unknown): unknown {
+  if (!(value instanceof Error)) {
+    return value;
+  }
+
+  const tag = (value as { _tag?: unknown })._tag;
+
+  if (typeof tag !== "string") {
+    return value;
+  }
+
+  const summary: Record<string, unknown> = {
+    _tag: tag,
+    message: value.message,
+  };
+
+  for (const name of Object.getOwnPropertyNames(value)) {
+    if (name === "stack" || name === "message" || name === "_tag") {
+      continue;
+    }
+
+    summary[name] = (value as unknown as Record<string, unknown>)[name];
+  }
+
+  return summary;
 }
 
 function encode_remote_failure(failure: unknown): never {

--- a/modules/svelte-effect-runtime/v4/preprocess.ts
+++ b/modules/svelte-effect-runtime/v4/preprocess.ts
@@ -46,3 +46,8 @@ export function effect_preprocess(
 ): PreprocessorGroup {
   return create_effect_preprocess(with_v4_effect_preprocess_options(options));
 }
+
+/**
+ * Backwards-compatible camelCase alias retained for older downstream imports.
+ */
+export const effectPreprocess = effect_preprocess;


### PR DESCRIPTION
## Summary
- flatten transported remote domain failures back onto the user-facing Effect error channel
- make `<script effect>` hover/mapping/type flow behave like normal Svelte/TypeScript for lowered bindings and markup references
- bump the runtime, language server, and VS Code extension versions to `1.4.0`

## Included
- remote client/server error transport updates so `catchTag`/`catchTags` work directly on user error tags
- effect script lowering improvements that preserve real symbol types across script and markup
- language-server snapshot/mapping integration and hover regression coverage for checkout-style flows
- fallback preprocessing and defensive code-action guards for effect-enabled Svelte documents

## Verification
- `deno test --node-modules-dir=auto -A modules/svelte-effect-runtime-language-server/server.test.ts`
- `deno test --node-modules-dir=auto -A modules/svelte-effect-runtime/test/remote.test.ts modules/svelte-effect-runtime/test/transform.test.ts modules/svelte-effect-runtime/tests/v3/transform.behavior.test.ts modules/svelte-effect-runtime/tests/v4/transform.behavior.test.ts`
- `deno task package` in `modules/svelte-effect-runtime-vscode-extension`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release 1.4.0 tightens `<script effect>` type mapping and hovers with relocation-aware mapping, and forwards remote domain errors as your tagged errors so `Effect.catchTag` works directly. Updates `svelte-effect-runtime`, `svelte-effect-runtime-language-server`, and `svelte-effect-runtime-vscode` to 1.4.0.

- **New Features**
  - Remote errors: your tagged failures are no longer wrapped; `Effect.catchTag("YourTag", ...)` matches directly. Transport/HTTP/validation errors stay tagged as framework errors.
  - Language server: relocation-aware script mapper preserves real types in script and markup (hover, go‑to), including destructured yields. Adds a TS fallback preprocessor when no `preprocess` is configured and guards TS quick fixes against invalid ranges. Cleaner logs for tagged failures.
  - Transformer: lowers `yield*` via typed helpers using `ReturnType` and a `__svelteEffectRuntimeYielded<T>` utility, emitting relocation ranges so names and expressions map cleanly. Destructured bindings map each name to its generated symbol to keep hovers accurate.

- **Migration**
  - If you matched `RemoteDomainError`, switch to catching your own tag (e.g. `Effect.catchTag("ProviderBusyError", ...)`) and read fields directly on that error. The `RemoteDomainError` type is kept but deprecated; avoid unwrapping `error.cause`/`status`.

<sup>Written for commit 91af7b77d6fa273dd7dbed2ea9217814bb3811d3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

